### PR TITLE
remove ACIS in FindSimmetrix and make parasolid optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ option(SIMMETRIX "Use simmetrix libraries" OFF)
 set(SIMMETRIX_ROOT "" CACHE STRING "Root directory of simmetrix dev files")
 set(SIM_MPI "mpich3" CACHE STRING "MPI version used by simmetrix")
 option(NETCDF "Use netcdf" OFF)
+option(PARASOLID "enable support for parasolid files" OFF)
 set(LOG_LEVEL "info" CACHE STRING "Log level for the code")
 set_property(CACHE LOG_LEVEL PROPERTY STRINGS "debug" "info" "warning" "error")
 
@@ -35,6 +36,10 @@ target_include_directories(pumgen PUBLIC src
   "${CMAKE_CURRENT_SOURCE_DIR}/src"
   "${CMAKE_CURRENT_SOURCE_DIR}/submodules/"
 )
+
+if (PARASOLID)
+  target_compile_definitions(pumgen PUBLIC PARASOLID)
+endif()
 
 if (NETCDF)
   find_package(NetCDF REQUIRED)

--- a/cmake/FindSimmetrix.cmake
+++ b/cmake/FindSimmetrix.cmake
@@ -15,12 +15,13 @@ find_library(APF_SIM_LIB apf_sim)
 
 set(SIM_LIB_HINT ${SIMMETRIX_ROOT}/lib/x64_rhel7_gcc48)
 
-find_library(SIM_ACIS_LIB NAMES SimAcis2019 SimAcis2020 PATHS ${SIM_LIB_HINT})
 find_library(SIM_DISCRETE_LIB SimDiscrete ${SIM_LIB_HINT})
 find_library(SIM_MESHING_LIB SimMeshing ${SIM_LIB_HINT})
 find_library(SIM_MESH_TOOLS_LIB SimMeshTools ${SIM_LIB_HINT})
 find_library(SIM_MODEL_LIB SimModel ${SIM_LIB_HINT})
+if (PARASOLID)
 find_library(SIM_PARASOLID_LIB NAMES SimParasolid310 SimParasolid320 PATHS ${SIM_LIB_HINT})
+endif()
 find_library(SIM_PARTITIONED_MESH_LIB SimPartitionedMesh ${SIM_LIB_HINT})
 find_library(SIM_PARTITIONED_MESH_MPI_LIB SimPartitionedMesh-mpi ${SIM_LIB_HINT})
 find_library(SIM_PARTITINED_WRAPPER_LIB SimPartitionWrapper-${SIM_MPI} ${SIM_LIB_HINT})
@@ -31,17 +32,21 @@ get_filename_component(SIM_PS_KRNL_LIB_DIR ${SIM_PS_KRNL_LIB} DIRECTORY)
 list(APPEND SIMMETRIX_LIBRARIES
   "${GMI_SIM_LIB}"
   "${APF_SIM_LIB}"
-  "${SIM_ACIS_LIB}"
   "${SIM_DISCRETE_LIB}"
   "${SIM_EXPORT_LIB}"
   "${SIM_MESHING_LIB}"
   "${SIM_MESH_TOOLS_LIB}"
-  "${SIM_PARASOLID_LIB}"
   "${SIM_PARTITIONED_MESH_MPI_LIB}"
   "${SIM_PARTITINED_WRAPPER_LIB}"
   "${SIM_MODEL_LIB}"
   "${SIM_PS_KRNL_LIB}"
 )
+
+if (PARASOLID)
+list(APPEND SIMMETRIX_LIBRARIES
+  "${SIM_PARASOLID_LIB}"
+)
+endif()
 
 string(REGEX REPLACE ".*/([0-9]+).[0-9]-.*" "\\1" SIM_MAJOR_VER ${SIM_MODEL_LIB})
 find_package_handle_standard_args(SIMMETRIX DEFAULT_MSG

--- a/src/input/SimModSuite.h
+++ b/src/input/SimModSuite.h
@@ -33,7 +33,9 @@
 #include <SimMeshingErrorCodes.h>
 #include <SimModel.h>
 #include <SimModelerUtil.h>
+#ifdef PARASOLID
 #include <SimParasolidKrnl.h>
+#endif
 #include <SimPartitionedMesh.h>
 
 #include "utils/logger.h"
@@ -88,7 +90,9 @@ class SimModSuite : public MeshInput {
     Sim_readLicenseFile(licenseFile);
     MS_init();
     SimDiscrete_start(0);
+#ifdef PARASOLID
     SimParasolid_start(1);
+#endif
     Sim_setMessageHandler(messageHandler);
 
     // Load CAD
@@ -223,7 +227,9 @@ class SimModSuite : public MeshInput {
     // GM_release(m_model);
 
     // Finalize SimModSuite
+#ifdef PARASOLID
     SimParasolid_stop(1);
+#endif
     SimDiscrete_stop(0);
     MS_exit();
     Sim_unregisterAllKeys();
@@ -547,9 +553,10 @@ class SimModSuite : public MeshInput {
       utils::StringUtils::replaceLast(sCadFile, ".smd", "_nat.x_t");
     }
     pNativeModel nativeModel = 0L;
+#ifdef PARASOLID
     if (utils::Path(sCadFile).exists())
       nativeModel = ParasolidNM_createFromFile(sCadFile.c_str(), 0);
-
+#endif
     m_model = GM_load(modFile, nativeModel, 0L);
     nativeModel = GM_nativeModel(m_model);
 

--- a/src/pumgen.cpp
+++ b/src/pumgen.cpp
@@ -68,7 +68,9 @@ int main(int argc, char* argv[]) {
   args.addOption("vtk", 0, "Dump mesh to VTK files", utils::Args::Required, false);
   args.addOption("license", 'l', "License file (only used by SimModSuite)", utils::Args::Required,
                  false);
+#ifdef PARASOLID
   args.addOption("cad", 'c', "CAD file (only used by SimModSuite)", utils::Args::Required, false);
+#endif
   args.addOption("mesh", 0, "Mesh attributes name (only used by SimModSuite, default: \"mesh\")",
                  utils::Args::Required, false);
   args.addOption("analysis", 0,


### PR DESCRIPTION
pumgen is currently compiled with ACIS and Parasolid library.
But ACIS is not used, and Parasolid is in most cases not used.
This PR should allow our collaborators from IRSN to compile and use pumgen without these libraries (and then avoid buying the associated licenses).
