### PR TITLE
Velocity aware meshes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "submodules/easi"]
 	path = submodules/easi
 	url = ../../SeisSol/easi.git
+[submodule "submodules/yaml-cpp"]
+	path = submodules/yaml-cpp
+	url = ../../jbeder/yaml-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "submodules/run-clang-format"]
 	path = submodules/run-clang-format
 	url = ../../Sarcasm/run-clang-format.git
+[submodule "submodules/easi"]
+	path = submodules/easi
+	url = ../../SeisSol/easi.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "submodules/yaml-cpp"]
 	path = submodules/yaml-cpp
 	url = ../../jbeder/yaml-cpp.git
+[submodule "submodules/ImpalaJIT"]
+	path = submodules/ImpalaJIT
+	url = ../../uphoffc/ImpalaJIT.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,12 +10,3 @@
 [submodule "submodules/run-clang-format"]
 	path = submodules/run-clang-format
 	url = ../../Sarcasm/run-clang-format.git
-[submodule "submodules/easi"]
-	path = submodules/easi
-	url = ../../SeisSol/easi.git
-[submodule "submodules/yaml-cpp"]
-	path = submodules/yaml-cpp
-	url = ../../jbeder/yaml-cpp.git
-[submodule "submodules/ImpalaJIT"]
-	path = submodules/ImpalaJIT
-	url = ../../uphoffc/ImpalaJIT.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,55 +79,9 @@ target_link_libraries(pumgen PUBLIC tinyxml2)
 if (SIMMETRIX)
     find_package(SIMMETRIX REQUIRED)
 
-    # Libs
-    include(ExternalProject)
-
-    find_package(YAML-CPP 0.6.3 QUIET)
-    if (YAML-CPP_FOUND)
-        target_link_libraries(SeisSol-lib PUBLIC ${YAML_CPP_LIBRARIES})
-        target_include_directories(SeisSol-lib PUBLIC ${YAML_CPP_INCLUDE_DIR})
-    else()
-        ExternalProject_Add(yaml-cpp-build
-                SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/submodules/yaml-cpp/
-                INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp-install
-                PREFIX ${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp
-                CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
-                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                -DYAML_CPP_BUILD_TOOLS=OFF
-                -DYAML_CPP_BUILD_TESTS=OFF
-                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                -DCMAKE_CXX_FLAGS=${EXTRA_CXX_FLAGS}
-                )
-        add_dependencies(pumgen yaml-cpp-build)
-        target_link_libraries(pumgen PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp-install/lib/libyaml-cpp.a")
-        target_include_directories(pumgen PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp-install/include/)
-    endif()
-
-    ExternalProject_Add(ImpalaJIT-build
-            SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/submodules/ImpalaJIT/
-            INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/ImpalaJIT-install
-            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ImpalaJIT
-            CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-            -DCMAKE_CXX_FLAGS=${EXTRA_CXX_FLAGS}
-            )
-    add_dependencies(pumgen ImpalaJIT-build)
-    target_link_libraries(pumgen PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/ImpalaJIT-install/lib/libimpalajit.a")
-    target_include_directories(pumgen PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/ImpalaJIT-install/include/)
-
-    # asagi
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(ASAGI REQUIRED asagi)
-    target_compile_definitions(pumgen PUBLIC USE_ASAGI)
-    target_link_libraries(pumgen PUBLIC ${ASAGI_STATIC_LDFLAGS})
-    target_include_directories(pumgen PUBLIC ${ASAGI_INCLUDE_DIRS})
-    target_compile_options(pumgen PUBLIC ${ASAGI_CFLAGS} ${ASAGI_CFLAGS_OTHER})
-
     # easi
-    target_include_directories(pumgen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/submodules/easi/include/)
+    find_package(easi 1.0.0 REQUIRED)
+    target_link_libraries(pumgen PUBLIC easi::easi)
 
     target_sources(pumgen PUBLIC 
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/AnalysisAttributes.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ if (SIMMETRIX)
     find_package(SIMMETRIX REQUIRED)
     target_sources(pumgen PUBLIC 
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/AnalysisAttributes.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/input/EasiMeshSize.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/MeshAttributes.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/ParallelVertexFilter.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/split.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,8 +144,6 @@ if (SIMMETRIX)
     endif()
     target_include_directories(pumgen PUBLIC ${SIMMETRIX_INCLUDE_DIR})
     target_link_libraries(pumgen PUBLIC ${SIMMETRIX_LIBRARIES})
-
-    target_link_libraries(pumgen PUBLIC tirpc) # Only for Fedora
 endif()
 
 function(cast_log_level_to_int log_level_str log_level_int)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(pumgen
   ${CMAKE_CURRENT_SOURCE_DIR}/src/meshreader/FidapReader.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/meshreader/GambitReader.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/meshreader/ParallelGMSHReader.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/input/ParallelVertexFilter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/GMSHLexer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/GMSHParser.cpp
   )
@@ -87,7 +88,6 @@ if (SIMMETRIX)
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/AnalysisAttributes.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/EasiMeshSize.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/MeshAttributes.cpp
-      ${CMAKE_CURRENT_SOURCE_DIR}/src/input/ParallelVertexFilter.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/split.cpp
     )
     target_compile_definitions(pumgen PUBLIC USE_SIMMOD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,14 @@ if (SIMMETRIX)
     target_link_libraries(pumgen PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/ImpalaJIT-install/lib/libimpalajit.a")
     target_include_directories(pumgen PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/ImpalaJIT-install/include/)
 
+    # asagi
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(ASAGI REQUIRED asagi)
+    target_compile_definitions(pumgen PUBLIC USE_ASAGI)
+    target_link_libraries(pumgen PUBLIC ${ASAGI_STATIC_LDFLAGS})
+    target_include_directories(pumgen PUBLIC ${ASAGI_INCLUDE_DIRS})
+    target_compile_options(pumgen PUBLIC ${ASAGI_CFLAGS} ${ASAGI_CFLAGS_OTHER})
+
     # easi
     target_include_directories(pumgen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/submodules/easi/include/)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ cmake_policy(SET CMP0074 NEW)
 
 project(pumgen LANGUAGES C CXX)
 
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
 option(SIMMETRIX "Use simmetrix libraries" OFF)
 set(SIMMETRIX_ROOT "" CACHE STRING "Root directory of simmetrix dev files")
 set(SIM_MPI "mpich3" CACHE STRING "MPI version used by simmetrix")
@@ -74,6 +78,49 @@ target_link_libraries(pumgen PUBLIC tinyxml2)
 
 if (SIMMETRIX)
     find_package(SIMMETRIX REQUIRED)
+
+    # Libs
+    include(ExternalProject)
+
+    find_package(YAML-CPP 0.6.3 QUIET)
+    if (YAML-CPP_FOUND)
+        target_link_libraries(SeisSol-lib PUBLIC ${YAML_CPP_LIBRARIES})
+        target_include_directories(SeisSol-lib PUBLIC ${YAML_CPP_INCLUDE_DIR})
+    else()
+        ExternalProject_Add(yaml-cpp-build
+                SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/submodules/yaml-cpp/
+                INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp-install
+                PREFIX ${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp
+                CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
+                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                -DYAML_CPP_BUILD_TOOLS=OFF
+                -DYAML_CPP_BUILD_TESTS=OFF
+                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                -DCMAKE_CXX_FLAGS=${EXTRA_CXX_FLAGS}
+                )
+        add_dependencies(pumgen yaml-cpp-build)
+        target_link_libraries(pumgen PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp-install/lib/libyaml-cpp.a")
+        target_include_directories(pumgen PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp-install/include/)
+    endif()
+
+    ExternalProject_Add(ImpalaJIT-build
+            SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/submodules/ImpalaJIT/
+            INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/ImpalaJIT-install
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ImpalaJIT
+            CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+            -DCMAKE_CXX_FLAGS=${EXTRA_CXX_FLAGS}
+            )
+    add_dependencies(pumgen ImpalaJIT-build)
+    target_link_libraries(pumgen PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/ImpalaJIT-install/lib/libimpalajit.a")
+    target_include_directories(pumgen PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/ImpalaJIT-install/include/)
+
+    # easi
+    target_include_directories(pumgen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/submodules/easi/include/)
+
     target_sources(pumgen PUBLIC 
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/AnalysisAttributes.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/src/input/EasiMeshSize.cpp
@@ -89,6 +136,8 @@ if (SIMMETRIX)
     endif()
     target_include_directories(pumgen PUBLIC ${SIMMETRIX_INCLUDE_DIR})
     target_link_libraries(pumgen PUBLIC ${SIMMETRIX_LIBRARIES})
+
+    target_link_libraries(pumgen PUBLIC tirpc) # Only for Fedora
 endif()
 
 function(cast_log_level_to_int log_level_str log_level_int)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
-
-add_executable(pumgen 
+add_executable(pumgen
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pumgen.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/meshreader/FidapReader.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/meshreader/GambitReader.cpp

--- a/XmlExample/meshAttributes.xml
+++ b/XmlExample/meshAttributes.xml
@@ -24,3 +24,4 @@
 <UseDiscreteMesh noModification="1">1</UseDiscreteMesh>
 <surfaceNoMesh>1,2</surfaceNoMesh>
 <regionNoMesh>1,4</regionNoMesh>
+<velocityAwareMeshing frequency="10" elementsPerWaveLength="2">easiFile.yaml</velocityAwareMeshing>

--- a/XmlExample/meshAttributes.xml
+++ b/XmlExample/meshAttributes.xml
@@ -26,5 +26,5 @@
 <regionNoMesh>1,4</regionNoMesh>
 <VelocityAwareMeshing easiFile="easiFile.yaml" elementsPerWaveLength="2">
     <VelocityRefinementCuboid frequency="10" centerX="0" centerY="0" centerZ="0"
-                              extentX="100" extentY="100" extentZ="100" />
+                              halfSizeX="100" halfSizeY="100" halfSizeZ="100" />
 </VelocityAwareMeshing>

--- a/XmlExample/meshAttributes.xml
+++ b/XmlExample/meshAttributes.xml
@@ -13,15 +13,18 @@
 <gradation value="0.3"/>
 <area_AspectRatio value="4"/>
 <vol_AspectRatio value="6"/>
-<SurfaceMeshing SmoothingLevel="3" SmoothingType="Gradient" DiscreteAngle="1.0" Snap="0"></SurfaceMeshing>
-<VolumeMeshing  SmoothingLevel="2" SmoothingType="Laplacian" SetOptimisation="1"></VolumeMeshing>
+<SurfaceMeshing SmoothingLevel="3" SmoothingType="Gradient" DiscreteAngle="1.0" Snap="0"/>
+<VolumeMeshing SmoothingLevel="2" SmoothingType="Laplacian" SetOptimisation="1"/>
 <MeshRefinementZoneCube value="1000">
-<Center x="0" y="0" z="-10e3"/>
-<HalfWidth x="20e3" y="0" z="0"/>
-<HalfHeight x="20e3" y="0" z="10e3"/>
-<HalfDepth x="0e3" y="2e3" z="0"/>
+    <Center x="0" y="0" z="-10e3"/>
+    <HalfWidth x="20e3" y="0" z="0"/>
+    <HalfHeight x="20e3" y="0" z="10e3"/>
+    <HalfDepth x="0e3" y="2e3" z="0"/>
 </MeshRefinementZoneCube>
 <UseDiscreteMesh noModification="1">1</UseDiscreteMesh>
 <surfaceNoMesh>1,2</surfaceNoMesh>
 <regionNoMesh>1,4</regionNoMesh>
-<velocityAwareMeshing frequency="10" elementsPerWaveLength="2">easiFile.yaml</velocityAwareMeshing>
+<VelocityAwareMeshing easiFile="easiFile.yaml" elementsPerWaveLength="2">
+    <VelocityRefinementCuboid frequency="10" centerX="0" centerY="0" centerZ="0"
+                              extentX="100" extentY="100" extentZ="100" />
+</VelocityAwareMeshing>

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -53,11 +53,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 find_path(NetCDF_INCLUDE_DIR
   NAMES netcdf.h
+  HINTS $ENV{NETCDF_DIR}/include $ENV{NETCDF_INCLUDE_DIR}
   DOC "netcdf include directories")
 mark_as_advanced(NetCDF_INCLUDE_DIR)
 
 find_library(NetCDF_LIBRARY
   NAMES netcdf
+  HINTS $ENV{NETCDF_DIR}/lib $ENV{NETCDF_LIB_DIR}
   DOC "netcdf library")
 mark_as_advanced(NetCDF_LIBRARY)
 

--- a/cmake/FindSIMMETRIX.cmake
+++ b/cmake/FindSIMMETRIX.cmake
@@ -48,6 +48,14 @@ list(APPEND SIMMETRIX_LIBRARIES
 )
 endif()
 
+# Workaround for Fedora:
+# Needs to manually link with TIRPC
+# Optional on most other distributions!
+find_library(TIRPC tirpc)
+if (TIRPC)
+    list(APPEND SIMMETRIX_LIBRARIES ${TIRPC})
+endif()
+
 string(REGEX REPLACE ".*/([0-9]+).[0-9]-.*" "\\1" SIM_MAJOR_VER ${SIM_MODEL_LIB})
 find_package_handle_standard_args(SIMMETRIX DEFAULT_MSG
   SIMMETRIX_INCLUDE_DIR SIMMETRIX_LIBRARIES SIM_MAJOR_VER)

--- a/src/input/EasiMeshSize.cpp
+++ b/src/input/EasiMeshSize.cpp
@@ -1,5 +1,4 @@
 #include "EasiMeshSize.h"
-#include <easi/YAMLParser.h>
 #include <utils/logger.h>
 
 

--- a/src/input/EasiMeshSize.cpp
+++ b/src/input/EasiMeshSize.cpp
@@ -31,9 +31,9 @@ double EasiMeshSize::getTargetedFrequency(std::array<double, 3> point) const {
     auto& cuboid = refinementCube.cuboid;
     bool isInCuboid = true;
     for (int i = 0; i < 3; ++i) {
-      const auto minCoord = cuboid.center[0] - cuboid.extent[0];
-      const auto maxCoord = cuboid.center[0] + cuboid.extent[0];
-      isInCuboid &= minCoord < point[i] && point[i] < maxCoord;
+      const auto minCoord = cuboid.center[i] - cuboid.extent[i];
+      const auto maxCoord = cuboid.center[i] + cuboid.extent[i];
+      isInCuboid &= minCoord <= point[i] && point[i] <= maxCoord;
     }
     if (isInCuboid) {
       targetedFrequency = std::max(targetedFrequency, refinementCube.targetedFrequency);

--- a/src/input/EasiMeshSize.cpp
+++ b/src/input/EasiMeshSize.cpp
@@ -1,5 +1,5 @@
 #include "EasiMeshSize.h"
-#include "easi/YAMLParser.h"
+#include <easi/YAMLParser.h>
 #include <utils/logger.h>
 
 

--- a/src/input/EasiMeshSize.cpp
+++ b/src/input/EasiMeshSize.cpp
@@ -8,15 +8,30 @@ EasiMeshSize::EasiMeshSize() : parser(nullptr), model(nullptr) {
 }
 
 EasiMeshSize::EasiMeshSize(std::string easiFileName, double targetedFrequency,
-                           double elementsPerWaveLength, pGModel simModel)
+                           double elementsPerWaveLength, pGModel simModel,
+                           std::unordered_map<pGRegion, int> groupMap)
     :
     easiFileName(easiFileName), targetedFrequency(targetedFrequency),
     elementsPerWaveLength(elementsPerWaveLength),
     simModel(simModel),
-    parser(new easi::YAMLParser(3)) {
+    parser(new easi::YAMLParser(3)),
+    groupMap(groupMap) {
   std::cout << "EasiMeshSize(easiFileName) called" << std::endl;
   model = parser->parse(easiFileName);
 }
+
+int EasiMeshSize::findGroup(std::array<double, 3> point) {
+  GRIter regionIt = GM_regionIter(simModel);
+  while (pGRegion region = GRIter_next(regionIt)) {
+    // Note: Does not work on discrete regions!
+    if (GR_containsPoint(region, point.data()) > 0) {
+      assert(groupMap.count(region) > 0);
+      return groupMap[region];
+    }
+  }
+  return -1;
+}
+
 double EasiMeshSize::getMeshSize(std::array<double, 3> point) {
   if (!model) {
     logError() << "Model was not parsed correctly";
@@ -50,3 +65,4 @@ EasiMeshSize::~EasiMeshSize() {
   //delete parser;
   //delete model;
 }
+

--- a/src/input/EasiMeshSize.cpp
+++ b/src/input/EasiMeshSize.cpp
@@ -31,8 +31,8 @@ double EasiMeshSize::getTargetedFrequency(std::array<double, 3> point) const {
     auto& cuboid = refinementCube.cuboid;
     bool isInCuboid = true;
     for (int i = 0; i < 3; ++i) {
-      const auto minCoord = cuboid.center[i] - cuboid.extent[i];
-      const auto maxCoord = cuboid.center[i] + cuboid.extent[i];
+      const auto minCoord = cuboid.center[i] - cuboid.halfSize[i];
+      const auto maxCoord = cuboid.center[i] + cuboid.halfSize[i];
       isInCuboid &= minCoord <= point[i] && point[i] <= maxCoord;
     }
     if (isInCuboid) {
@@ -82,4 +82,3 @@ double EasiMeshSize::getMeshSize(std::array<double, 3> point) {
   const auto waveLength = waveSpeed / targetedFrequency;
   return waveLength / refinementSettings.getElementsPerWaveLength();
 }
-EasiMeshSize::~EasiMeshSize() = default;

--- a/src/input/EasiMeshSize.cpp
+++ b/src/input/EasiMeshSize.cpp
@@ -3,7 +3,6 @@
 
 
 EasiMeshSize::EasiMeshSize() : parser(nullptr), model(nullptr) {
-  std::cout << "EasiMeshSize() called" << std::endl;
 }
 
 EasiMeshSize::EasiMeshSize(std::string easiFileName, double targetedFrequency,
@@ -15,7 +14,6 @@ EasiMeshSize::EasiMeshSize(std::string easiFileName, double targetedFrequency,
     simModel(simModel),
     parser(new easi::YAMLParser(3)),
     groupMap(groupMap) {
-  std::cout << "EasiMeshSize(easiFileName) called" << std::endl;
   model = parser->parse(easiFileName);
 }
 
@@ -60,8 +58,5 @@ double EasiMeshSize::getMeshSize(std::array<double, 3> point) {
   return waveLength / elementsPerWaveLength;
 }
 EasiMeshSize::~EasiMeshSize() {
-  std::cout << "Destructor of EasiMeshSize called" << std::endl;
-  //delete parser;
-  //delete model;
 }
 

--- a/src/input/EasiMeshSize.cpp
+++ b/src/input/EasiMeshSize.cpp
@@ -1,0 +1,2 @@
+#include "EasiMeshSize.h"
+

--- a/src/input/EasiMeshSize.cpp
+++ b/src/input/EasiMeshSize.cpp
@@ -1,2 +1,51 @@
 #include "EasiMeshSize.h"
+#include "easi/YAMLParser.h"
+#include <utils/logger.h>
 
+
+EasiMeshSize::EasiMeshSize() : parser(nullptr), model(nullptr) {
+  std::cout << "EasiMeshSize() called" << std::endl;
+}
+
+EasiMeshSize::EasiMeshSize(std::string easiFileName) :
+    parser(new easi::YAMLParser(3)), easiFileName(easiFileName){
+  std::cout << "EasiMeshSize(easiFileName) called" << std::endl;
+  model = parser->parse(easiFileName);
+}
+double EasiMeshSize::getMeshSize(std::array<double, 3> point) {
+  if (!model) {
+    logError() << "Model was not parsed correctly";
+  }
+  auto query = easi::Query(1,3);
+  query.x(0,0) = point[0];
+  query.x(0,1) = point[1];
+  query.x(0,2) = point[2];
+  query.group(0) = 0;
+
+  // Need array for easi interface
+  auto materials = std::array<ElasticMaterial,1>();
+  auto& material = materials[0];
+  auto adapter = easi::ArrayOfStructsAdapter<ElasticMaterial>(materials.data());
+  adapter.addBindingPoint("lambda", &ElasticMaterial::lambda);
+  adapter.addBindingPoint("mu", &ElasticMaterial::mu);
+  adapter.addBindingPoint("rho", &ElasticMaterial::rho);
+
+  model->evaluate(query, adapter);
+
+  const auto pWaveSpeed = std::sqrt(
+      (material.lambda + 2 * material.mu ) / material.rho
+      );
+
+  std::cout << pWaveSpeed << std::endl;
+  // TODO: What to do about groups?
+  if(point[2] > 0 ) {
+    return 1.0;
+  } else {
+    return 0.1;
+  }
+}
+EasiMeshSize::~EasiMeshSize() {
+  std::cout << "Destructor of EasiMeshSize called" << std::endl;
+  delete parser;
+  delete model;
+}

--- a/src/input/EasiMeshSize.h
+++ b/src/input/EasiMeshSize.h
@@ -1,10 +1,12 @@
 #ifndef PUMGEN_EASIMESHSIZE_H
 #define PUMGEN_EASIMESHSIZE_H
 
+#include "easi/Component.h"
+#include <MeshTypes.h>
+#include <SimModel.h>
 #include <array>
 #include <memory>
 #include <string>
-#include "easi/Component.h"
 
 // Workaround for easi linking bug
 namespace easi {
@@ -15,13 +17,30 @@ struct ElasticMaterial {
 };
 
 class EasiMeshSize {
-  private:
+private:
+  std::string easiFileName;
+  double targetedFrequency;
+  double elementsPerWaveLength;
   easi::YAMLParser* parser;
   easi::Component* model; // Unique ptr to model leads to segfault
-  std::string easiFileName;
+  pGModel simModel;
+
+  int findGroup(std::array<double, 3> point) {
+    GRIter regionIt = GM_regionIter(simModel);
+    while (pGRegion region = GRIter_next(regionIt)) {
+      // Note: Does not work on discrete regions!
+      if (GR_containsPoint(region, point.data()) > 0) {
+        return GEN_tag(region);
+      }
+
+      return -1;
+    }
+  }
+
   public:
   EasiMeshSize();;
-  EasiMeshSize(std::string easiFileName);
+  EasiMeshSize(std::string easiFileName, double targetedFrequency, double elementsPerWaveLength,
+               pGModel simModel);
 
   double getMeshSize(std::array<double, 3> point);
 

--- a/src/input/EasiMeshSize.h
+++ b/src/input/EasiMeshSize.h
@@ -1,0 +1,22 @@
+#ifndef PUMGEN_EASIMESHSIZE_H
+#define PUMGEN_EASIMESHSIZE_H
+
+#include <array>
+#include <string_view>
+
+class EasiMeshSize {
+  public:
+  EasiMeshSize(std::string_view easiFileName) {
+    // TODO(Lukas) Do something
+  }
+
+  double getMeshSize(std::array<double, 3> point) {
+    if(point[2] > 0 ) {
+      return 1.0;
+    } else {
+      return 0.1;
+    }
+  }
+};
+
+#endif // PUMGEN_EASIMESHSIZE_H

--- a/src/input/EasiMeshSize.h
+++ b/src/input/EasiMeshSize.h
@@ -2,21 +2,30 @@
 #define PUMGEN_EASIMESHSIZE_H
 
 #include <array>
-#include <string_view>
+#include <memory>
+#include <string>
+#include "easi/Component.h"
+
+// Workaround for easi linking bug
+namespace easi {
+class YAMLParser;
+}
+struct ElasticMaterial {
+  double lambda, mu, rho;
+};
 
 class EasiMeshSize {
+  private:
+  easi::YAMLParser* parser;
+  easi::Component* model; // Unique ptr to model leads to segfault
+  std::string easiFileName;
   public:
-  EasiMeshSize(std::string_view easiFileName) {
-    // TODO(Lukas) Do something
-  }
+  EasiMeshSize();;
+  EasiMeshSize(std::string easiFileName);
 
-  double getMeshSize(std::array<double, 3> point) {
-    if(point[2] > 0 ) {
-      return 1.0;
-    } else {
-      return 0.1;
-    }
-  }
+  double getMeshSize(std::array<double, 3> point);
+
+  ~EasiMeshSize();
 };
 
 #endif // PUMGEN_EASIMESHSIZE_H

--- a/src/input/EasiMeshSize.h
+++ b/src/input/EasiMeshSize.h
@@ -1,11 +1,12 @@
 #ifndef PUMGEN_EASIMESHSIZE_H
 #define PUMGEN_EASIMESHSIZE_H
 
-#include <easi/YAMLParser.h>
-#include <easi/Component.h>
+#include "MeshAttributes.h"
 #include <MeshTypes.h>
 #include <SimModel.h>
 #include <array>
+#include <easi/Component.h>
+#include <easi/YAMLParser.h>
 #include <memory>
 #include <string>
 
@@ -14,10 +15,9 @@ struct ElasticMaterial {
 };
 
 class EasiMeshSize {
-private:
-  std::string easiFileName;
-  double targetedFrequency;
-  double elementsPerWaveLength;
+  private:
+  VelocityAwareRefinementSettings refinementSettings;
+
   easi::YAMLParser* parser;
   easi::Component* model; // Unique ptr to model leads to segfault
   pGModel simModel;
@@ -25,10 +25,13 @@ private:
 
   int findGroup(std::array<double, 3> point);
 
+  double getTargetedFrequency(std::array<double, 3> point) const;
+
   public:
-  EasiMeshSize();;
-  EasiMeshSize(std::string easiFileName, double targetedFrequency, double elementsPerWaveLength,
-               pGModel simModel, std::unordered_map<pGRegion, int> groupMap);
+  EasiMeshSize();
+  ;
+  EasiMeshSize(VelocityAwareRefinementSettings refinementSettings, pGModel simModel,
+               std::unordered_map<pGRegion, int> groupMap);
 
   double getMeshSize(std::array<double, 3> point);
 

--- a/src/input/EasiMeshSize.h
+++ b/src/input/EasiMeshSize.h
@@ -24,23 +24,14 @@ private:
   easi::YAMLParser* parser;
   easi::Component* model; // Unique ptr to model leads to segfault
   pGModel simModel;
+  std::unordered_map<pGRegion, int> groupMap;
 
-  int findGroup(std::array<double, 3> point) {
-    GRIter regionIt = GM_regionIter(simModel);
-    while (pGRegion region = GRIter_next(regionIt)) {
-      // Note: Does not work on discrete regions!
-      if (GR_containsPoint(region, point.data()) > 0) {
-        return GEN_tag(region);
-      }
-
-      return -1;
-    }
-  }
+  int findGroup(std::array<double, 3> point);
 
   public:
   EasiMeshSize();;
   EasiMeshSize(std::string easiFileName, double targetedFrequency, double elementsPerWaveLength,
-               pGModel simModel);
+               pGModel simModel, std::unordered_map<pGRegion, int> groupMap);
 
   double getMeshSize(std::array<double, 3> point);
 

--- a/src/input/EasiMeshSize.h
+++ b/src/input/EasiMeshSize.h
@@ -1,17 +1,14 @@
 #ifndef PUMGEN_EASIMESHSIZE_H
 #define PUMGEN_EASIMESHSIZE_H
 
-#include "easi/Component.h"
+#include <easi/YAMLParser.h>
+#include <easi/Component.h>
 #include <MeshTypes.h>
 #include <SimModel.h>
 #include <array>
 #include <memory>
 #include <string>
 
-// Workaround for easi linking bug
-namespace easi {
-class YAMLParser;
-}
 struct ElasticMaterial {
   double lambda, mu, rho;
 };

--- a/src/input/EasiMeshSize.h
+++ b/src/input/EasiMeshSize.h
@@ -34,8 +34,6 @@ class EasiMeshSize {
                std::unordered_map<pGRegion, int> groupMap);
 
   double getMeshSize(std::array<double, 3> point);
-
-  ~EasiMeshSize();
 };
 
 #endif // PUMGEN_EASIMESHSIZE_H

--- a/src/input/MeshAttributes.cpp
+++ b/src/input/MeshAttributes.cpp
@@ -177,24 +177,24 @@ void MeshAttributes::set_velocity_aware_meshing() {
     logInfo() << "Activating velocity aware meshing, using" << elementsPerWaveLength
               << "elements per wavelength and easi file" << easiFileName;
     for (auto child = velocityAwareMeshingElement->FirstChildElement(cuboidName); child;
-         child = child->NextSiblingElement(name)) {
+         child = child->NextSiblingElement(cuboidName)) {
       auto cuboid = SimpleCuboid{{
                                      std::stof(child->Attribute("centerX")),
                                      std::stof(child->Attribute("centerY")),
                                      std::stof(child->Attribute("centerZ")),
                                  },
                                  {
-                                     std::stof(child->Attribute("extentX")),
-                                     std::stof(child->Attribute("extentY")),
-                                     std::stof(child->Attribute("extentZ")),
+                                     std::stof(child->Attribute("halfSizeX")),
+                                     std::stof(child->Attribute("halfSizeY")),
+                                     std::stof(child->Attribute("halfSizeZ")),
                                  }};
       const auto targetedFrequency = std::stof(child->Attribute("frequency"));
       velocityAwareRefinementSettings.addRefinementRegion(cuboid, targetedFrequency);
       logInfo() << "Adding velocity aware refinement region targeting" << targetedFrequency
                 << "Hz, centered at x =" << cuboid.center[0] << "y=" << cuboid.center[1]
-                << "z=" << cuboid.center[2] << "with extents"
-                << "x =" << cuboid.extent[0] << "y =" << cuboid.extent[1]
-                << "z =" << cuboid.extent[2];
+                << "z=" << cuboid.center[2] << "with half sizes"
+                << "x =" << cuboid.halfSize[0] << "y =" << cuboid.halfSize[1]
+                << "z =" << cuboid.halfSize[2];
     }
     if (!velocityAwareRefinementSettings.isVelocityAwareRefinementOn()) {
       logWarning() << "Activated velocity aware meshing but did not specify any refinement region!";

--- a/src/input/MeshAttributes.cpp
+++ b/src/input/MeshAttributes.cpp
@@ -144,7 +144,7 @@ void MeshAttributes::set_velocity_aware_meshing() {
   const auto name = "velocityAwareMeshing";
   for (auto child = doc.FirstChildElement(name);
        child;
-       child = child->NextSiblingElement("velocityAwareMeshing")) {
+       child = child->NextSiblingElement(name)) {
     useVelocityAwareMeshing = true;
     easiFileName = child->GetText();
     targetedFrequency = std::stof(child->Attribute("frequency"));

--- a/src/input/MeshAttributes.cpp
+++ b/src/input/MeshAttributes.cpp
@@ -19,6 +19,7 @@ void MeshAttributes::init(const char* xmlFilename) {
   set_MeshSizePropagation();
   set_regionMSize();
   set_global_mesh_attributes();
+  set_velocity_aware_meshing();
 }
 
 void MeshAttributes::readXmlFile(const char* xmlFilename) {
@@ -135,6 +136,24 @@ void MeshAttributes::set_regionMSize() {
        child = child->NextSiblingElement("regionMSize")) {
     lpair_lRegionId_MSize.push_back(std::make_pair(fill_list_using_parsed_string(child->GetText()),
                                                    std::atof(child->Attribute("value"))));
+  }
+}
+
+void MeshAttributes::set_velocity_aware_meshing() {
+  int numChilds = 0;
+  const auto name = "velocityAwareMeshing";
+  for (auto child = doc.FirstChildElement(name);
+       child;
+       child = child->NextSiblingElement("velocityAwareMeshing")) {
+    useVelocityAwareMeshing = true;
+    easiFileName = child->GetText();
+    targetedFrequency = std::stof(child->Attribute("frequency"));
+    elementsPerWaveLength = std::stof(child->Attribute("elementsPerWaveLength"));
+    ++numChilds;
+  }
+  if (numChilds > 1) {
+    logError() << "Multiple definitions of velocityAwareMeshing";
+
   }
 }
 

--- a/src/input/MeshAttributes.cpp
+++ b/src/input/MeshAttributes.cpp
@@ -174,8 +174,8 @@ void MeshAttributes::set_velocity_aware_meshing() {
     velocityAwareRefinementSettings =
         VelocityAwareRefinementSettings(elementsPerWaveLength, easiFileName);
     constexpr auto cuboidName = "VelocityRefinementCuboid";
-    logInfo() << "Activating velocity aware meshing, using" << elementsPerWaveLength
-              << "elements per wavelength and easi file" << easiFileName;
+    logInfo(PMU_rank()) << "Activating velocity aware meshing, using" << elementsPerWaveLength
+                        << "elements per wavelength and easi file" << easiFileName;
     for (auto child = velocityAwareMeshingElement->FirstChildElement(cuboidName); child;
          child = child->NextSiblingElement(cuboidName)) {
       auto cuboid = SimpleCuboid{{
@@ -190,14 +190,16 @@ void MeshAttributes::set_velocity_aware_meshing() {
                                  }};
       const auto targetedFrequency = std::stof(child->Attribute("frequency"));
       velocityAwareRefinementSettings.addRefinementRegion(cuboid, targetedFrequency);
-      logInfo() << "Adding velocity aware refinement region targeting" << targetedFrequency
-                << "Hz, centered at x =" << cuboid.center[0] << "y=" << cuboid.center[1]
-                << "z=" << cuboid.center[2] << "with half sizes"
-                << "x =" << cuboid.halfSize[0] << "y =" << cuboid.halfSize[1]
-                << "z =" << cuboid.halfSize[2];
+      logInfo(PMU_rank()) << "Adding velocity aware refinement region targeting"
+                          << targetedFrequency << "Hz, centered at x =" << cuboid.center[0]
+                          << "y=" << cuboid.center[1] << "z=" << cuboid.center[2]
+                          << "with half sizes"
+                          << "x =" << cuboid.halfSize[0] << "y =" << cuboid.halfSize[1]
+                          << "z =" << cuboid.halfSize[2];
     }
     if (!velocityAwareRefinementSettings.isVelocityAwareRefinementOn()) {
-      logWarning() << "Activated velocity aware meshing but did not specify any refinement region!";
+      logWarning(PMU_rank())
+          << "Activated velocity aware meshing but did not specify any refinement region!";
     }
     ++numChilds;
   }

--- a/src/input/MeshAttributes.h
+++ b/src/input/MeshAttributes.h
@@ -31,6 +31,9 @@ class MeshAttributes {
   int VolumeMesherOptimization = 1;
   double globalMSize = 0., faultMSize = 0., gradation = 0., vol_AspectRatio = 0.,
          area_AspectRatio = 0.;
+  bool useVelocityAwareMeshing = false;
+  double targetedFrequency = 0., elementsPerWaveLength = 0;
+  std::string easiFileName;
   const std::list<std::pair<std::list<int>, double>>& getMSizeList(ElementType type);
 
   std::list<std::pair<std::list<int>, double>> lpair_lVertexId_MSize;
@@ -63,6 +66,7 @@ class MeshAttributes {
   void set_MeshSizePropagation();
   void set_regionMSize();
   void set_global_mesh_attributes();
+  void set_velocity_aware_meshing();
   void update_attribute_from_xml(XMLNode& element, const char* sElementName,
                                  const char* sAttributeName, int& MeshAttributesMember);
   void update_attribute_from_xml(XMLNode& element, const char* sElementName,

--- a/src/input/MeshAttributes.h
+++ b/src/input/MeshAttributes.h
@@ -19,7 +19,7 @@ struct Cube {
 
 struct SimpleCuboid {
   std::array<double, 3> center;
-  std::array<double, 3> extent;
+  std::array<double, 3> halfSize;
 };
 
 struct VelocityRefinementCube {

--- a/src/input/MeshAttributes.h
+++ b/src/input/MeshAttributes.h
@@ -11,9 +11,44 @@
 
 // for PMU_rank()
 #include <SimPartitionedMesh.h>
+#include <optional>
 
 struct Cube {
   double CubeMSize = 0, CubeCenter[3], CubeWidth[3], CubeHeight[3], CubeDepth[3];
+};
+
+struct SimpleCuboid {
+  std::array<double, 3> center;
+  std::array<double, 3> extent;
+};
+
+struct VelocityRefinementCube {
+  VelocityRefinementCube(SimpleCuboid cuboid, double targetedFrequency)
+      : cuboid(cuboid), targetedFrequency(targetedFrequency){};
+
+  SimpleCuboid cuboid;
+  double targetedFrequency;
+};
+
+class VelocityAwareRefinementSettings {
+  public:
+  VelocityAwareRefinementSettings() = default;
+  VelocityAwareRefinementSettings(double elementsPerWaveLength, std::string easiFileName);
+
+  void addRefinementRegion(SimpleCuboid cuboid, double targetedFrequency);
+
+  [[nodiscard]] bool isVelocityAwareRefinementOn() const;
+
+  [[nodiscard]] const std::string& getEasiFileName() const;
+
+  [[nodiscard]] double getElementsPerWaveLength() const;
+
+  [[nodiscard]] const std::vector<VelocityRefinementCube>& getRefinementRegions() const;
+
+  private:
+  double elementsPerWaveLength{};
+  std::string easiFileName;
+  std::vector<VelocityRefinementCube> refinementRegions{};
 };
 
 enum class ElementType { vertex = 0, edge = 1, face = 2, region = 3 };
@@ -31,9 +66,7 @@ class MeshAttributes {
   int VolumeMesherOptimization = 1;
   double globalMSize = 0., faultMSize = 0., gradation = 0., vol_AspectRatio = 0.,
          area_AspectRatio = 0.;
-  bool useVelocityAwareMeshing = false;
-  double targetedFrequency = 0., elementsPerWaveLength = 0;
-  std::string easiFileName;
+  VelocityAwareRefinementSettings velocityAwareRefinementSettings;
   const std::list<std::pair<std::list<int>, double>>& getMSizeList(ElementType type);
 
   std::list<std::pair<std::list<int>, double>> lpair_lVertexId_MSize;

--- a/src/input/SimModSuite.h
+++ b/src/input/SimModSuite.h
@@ -45,6 +45,7 @@
 #include "MeshInput.h"
 
 #include "AnalysisAttributes.h"
+#include "EasiMeshSize.h"
 #include "MeshAttributes.h"
 
 #include <SimDisplay.h>
@@ -455,6 +456,25 @@ class SimModSuite : public MeshInput {
 
     // Set mesh size on vertices, edges, surfaces and regions
     setMeshSize(model, meshCase, MeshAtt);
+
+    // TODO(Lukas) Make configurable
+    if (true) {
+      auto easiMeshSize = EasiMeshSize("todo.yaml");
+      auto easiMeshSizeFunc = [](pSizeAttData sadata, void *userdata){
+        auto* easiMeshSize = static_cast<EasiMeshSize*>(userdata);
+        std::array<double, 3> pt{};
+        int haspt = SizeAttData_point(sadata, pt.data());
+        if (!haspt) {
+          logError() << "!haspt";
+        }
+        return easiMeshSize->getMeshSize(pt);
+        };
+      // set the user-defined function for anisotropic size
+      MS_setSizeAttFunc(meshCase, "setCustomMeshSize", easiMeshSizeFunc, &easiMeshSize);
+      // Relative anisotropic size is set for the entire model through the
+      // function anisoSize
+      MS_setMeshSize(meshCase, GM_domain(model), MS_userDefinedType | 2, 0, "setCustomMeshSize");
+    }
 
     if (MeshAtt.gradation > 0) {
       // Set gradation relative

--- a/src/input/SimModSuite.h
+++ b/src/input/SimModSuite.h
@@ -458,11 +458,12 @@ class SimModSuite : public MeshInput {
     // Set mesh size on vertices, edges, surfaces and regions
     setMeshSize(model, meshCase, MeshAtt);
 
-    // TODO(Lukas) Make configurable
-    if (true) {
-      const auto easiFile =
-          "/home/lukas/src/SeisSol-Examples/convergence_acoustic_elastic/convergence_snell/material.yaml";
-      easiMeshSize = EasiMeshSize(easiFile);
+    if (MeshAtt.useVelocityAwareMeshing) {
+      logInfo() << "Enabling velocity aware meshing";
+      easiMeshSize = EasiMeshSize(MeshAtt.easiFileName,
+                                  MeshAtt.targetedFrequency,
+                                  MeshAtt.elementsPerWaveLength,
+                                  model);
       auto easiMeshSizeFunc = [](pSizeAttData sadata, void *userdata){
         auto* easiMeshSize = static_cast<EasiMeshSize*>(userdata);
         std::array<double, 3> pt{};

--- a/src/input/SimModSuite.h
+++ b/src/input/SimModSuite.h
@@ -473,11 +473,11 @@ class SimModSuite : public MeshInput {
         }
         return easiMeshSize->getMeshSize(pt);
         };
-      // set the user-defined function for anisotropic size
+      // set the user-defined function for isotropic size
       MS_setSizeAttFunc(meshCase, "setCustomMeshSize", easiMeshSizeFunc, &easiMeshSize);
       // Relative anisotropic size is set for the entire model through the
       // function anisoSize
-      MS_setMeshSize(meshCase, GM_domain(model), MS_userDefinedType | 2, 0, "setCustomMeshSize");
+      MS_setMeshSize(meshCase, GM_domain(model), MS_userDefinedType | 1, 0, "setCustomMeshSize");
     }
 
     if (MeshAtt.gradation > 0) {

--- a/src/input/SimModSuite.h
+++ b/src/input/SimModSuite.h
@@ -68,6 +68,7 @@ pAManager SModel_attManager(pModel model);
  */
 class SimModSuite : public MeshInput {
   private:
+  EasiMeshSize easiMeshSize;
   pGModel m_model;
 
   pParMesh m_simMesh;
@@ -459,7 +460,9 @@ class SimModSuite : public MeshInput {
 
     // TODO(Lukas) Make configurable
     if (true) {
-      auto easiMeshSize = EasiMeshSize("todo.yaml");
+      const auto easiFile =
+          "/home/lukas/src/SeisSol-Examples/convergence_acoustic_elastic/convergence_snell/material.yaml";
+      easiMeshSize = EasiMeshSize(easiFile);
       auto easiMeshSizeFunc = [](pSizeAttData sadata, void *userdata){
         auto* easiMeshSize = static_cast<EasiMeshSize*>(userdata);
         std::array<double, 3> pt{};

--- a/src/input/SimModSuite.h
+++ b/src/input/SimModSuite.h
@@ -458,7 +458,7 @@ class SimModSuite : public MeshInput {
     setMeshSize(model, meshCase, MeshAtt);
 
     if (MeshAtt.velocityAwareRefinementSettings.isVelocityAwareRefinementOn()) {
-      logInfo() << "Enabling velocity aware meshing";
+      logInfo(PMU_rank()) << "Enabling velocity aware meshing";
       easiMeshSize = EasiMeshSize(MeshAtt.velocityAwareRefinementSettings, model, groupMap);
       auto easiMeshSizeFunc = [](pSizeAttData sadata, void* userdata) {
         auto* easiMeshSize = static_cast<EasiMeshSize*>(userdata);

--- a/src/input/SimModSuite.h
+++ b/src/input/SimModSuite.h
@@ -199,7 +199,6 @@ class SimModSuite : public MeshInput {
     }
     m_mesh->end(it);
 
-
     // Set groups
     apf::MeshTag* groupTag = m_mesh->createIntTag("group", 1);
     it = m_mesh->begin(3);
@@ -378,8 +377,7 @@ class SimModSuite : public MeshInput {
   }
 
   void setCases(pGModel model, pACase& meshCase, pACase& analysisCase, MeshAttributes& MeshAtt,
-                AnalysisAttributes& AnalysisAtt,
-                std::unordered_map<pGRegion, int> groupMap) {
+                AnalysisAttributes& AnalysisAtt, std::unordered_map<pGRegion, int> groupMap) {
 
     logInfo(PMU_rank()) << "Setting cases";
     // ------------------------------ Set boundary conditions
@@ -459,12 +457,10 @@ class SimModSuite : public MeshInput {
     // Set mesh size on vertices, edges, surfaces and regions
     setMeshSize(model, meshCase, MeshAtt);
 
-    if (MeshAtt.useVelocityAwareMeshing) {
+    if (MeshAtt.velocityAwareRefinementSettings.isVelocityAwareRefinementOn()) {
       logInfo() << "Enabling velocity aware meshing";
-      easiMeshSize =
-          EasiMeshSize(MeshAtt.easiFileName, MeshAtt.targetedFrequency,
-                       MeshAtt.elementsPerWaveLength, model, groupMap);
-      auto easiMeshSizeFunc = [](pSizeAttData sadata, void *userdata){
+      easiMeshSize = EasiMeshSize(MeshAtt.velocityAwareRefinementSettings, model, groupMap);
+      auto easiMeshSizeFunc = [](pSizeAttData sadata, void* userdata) {
         auto* easiMeshSize = static_cast<EasiMeshSize*>(userdata);
         std::array<double, 3> pt{};
         int haspt = SizeAttData_point(sadata, pt.data());
@@ -472,7 +468,7 @@ class SimModSuite : public MeshInput {
           logError() << "!haspt";
         }
         return easiMeshSize->getMeshSize(pt);
-        };
+      };
       // set the user-defined function for isotropic size
       MS_setSizeAttFunc(meshCase, "setCustomMeshSize", easiMeshSizeFunc, &easiMeshSize);
       // Relative anisotropic size is set for the entire model through the


### PR DESCRIPTION
This draft (!) PR adds the capability of of meshing in a velocity-aware manner.
You can have a look at the example XML file, especially the line
`<velocityAwareMeshing frequency="10" elementsPerWaveLength="2">easiFile.yaml</velocityAwareMeshing>`
This tries to resolve the p-wave with a frequency of 10 Hz using 2 elements per wave length.

Draft PR because 1) CI fails 2) it's not tested properly (but works on a toy example) 3) last day before vacation.

So, feel free to play around with this!