### PR TITLE
speed up velocity-aware mesh generation by allowing to bypass findRegion

### DIFF
--- a/XmlExample/meshAttributes.xml
+++ b/XmlExample/meshAttributes.xml
@@ -1,8 +1,10 @@
 <freeSurface>1</freeSurface>
 <dynamicRupture>2</dynamicRupture>
 <absorbing>3,4</absorbing>
-<boundaryCondition tag="7">7</boundaryCondition>
-<boundaryCondition tag="8">8,9</boundaryCondition>
+<!-- see https://seissol.readthedocs.io/en/latest/fault-tagging.html for SeisSol convention regarding boundaryCondition -->
+<boundaryCondition tag="65">7</boundaryCondition> 
+<boundaryCondition tag="67">7</boundaryCondition>
+<boundaryCondition tag="68">8,9</boundaryCondition>
 <globalMSize value="100e3"/>
 <vertexMSize value="1000">1,2</vertexMSize>
 <edgeMSize value="500">4,8</edgeMSize>
@@ -24,7 +26,16 @@
 <UseDiscreteMesh noModification="1">1</UseDiscreteMesh>
 <surfaceNoMesh>1,2</surfaceNoMesh>
 <regionNoMesh>1,4</regionNoMesh>
+
+<!-- For complex geometry, finding the region in which a point lies is expensive and will 
+slow down the mesh generation significantly when using VelocityAwareMeshing. 
+To avoid such an expensive call to the findGroup function, we can specify the group to use
+in the easi query using the (optional) argument bypassFindRegionAndUseGroup -->
+
 <VelocityAwareMeshing easiFile="easiFile.yaml" elementsPerWaveLength="2">
-    <VelocityRefinementCuboid frequency="10" centerX="0" centerY="0" centerZ="0"
+    <VelocityRefinementCuboid frequency="2" centerX="200" centerY="200" centerZ="-100"
                               halfSizeX="100" halfSizeY="100" halfSizeZ="100" />
+    <VelocityRefinementCuboid frequency="10" centerX="0" centerY="0" centerZ="0"
+                              halfSizeX="100" halfSizeY="100" halfSizeZ="100" 
+                              bypassFindRegionAndUseGroup="1"/>
 </VelocityAwareMeshing>

--- a/src/input/EasiMeshSize.cpp
+++ b/src/input/EasiMeshSize.cpp
@@ -59,9 +59,9 @@ double EasiMeshSize::getMeshSize(std::array<double, 3> point) {
   }
 
   constexpr double defaultMeshSize = std::numeric_limits<double>::max();
-  auto freqRegion = getTargetedFrequencyAndRegion(point);
-  const double targetedFrequency = std::get<0>(freqRegion);
-  const int bypassFindRegionAndUseGroup = std::get<1>(freqRegion);
+  const auto [targetedFrequency, bypassFindRegionAndUseGroup] =
+      getTargetedFrequencyAndRegion(point);
+
   if (targetedFrequency == 0.0) {
     return defaultMeshSize;
   }

--- a/src/input/EasiMeshSize.h
+++ b/src/input/EasiMeshSize.h
@@ -20,6 +20,7 @@ class EasiMeshSize {
 
   easi::YAMLParser* parser;
   easi::Component* model; // Unique ptr to model leads to segfault
+  easi::Query query;
   pGModel simModel;
   std::unordered_map<pGRegion, int> groupMap;
 

--- a/src/input/EasiMeshSize.h
+++ b/src/input/EasiMeshSize.h
@@ -26,7 +26,7 @@ class EasiMeshSize {
 
   int findGroup(std::array<double, 3> point);
 
-  double getTargetedFrequency(std::array<double, 3> point) const;
+  std::tuple<const double, const int> getTargetedFrequencyAndRegion(std::array<double, 3> point);
 
   public:
   EasiMeshSize();

--- a/src/input/MeshAttributes.h
+++ b/src/input/MeshAttributes.h
@@ -23,11 +23,14 @@ struct SimpleCuboid {
 };
 
 struct VelocityRefinementCube {
-  VelocityRefinementCube(SimpleCuboid cuboid, double targetedFrequency)
-      : cuboid(cuboid), targetedFrequency(targetedFrequency){};
+  VelocityRefinementCube(SimpleCuboid cuboid, double targetedFrequency,
+                         int bypassFindRegionAndUseGroup)
+      : cuboid(cuboid), targetedFrequency(targetedFrequency),
+        bypassFindRegionAndUseGroup(bypassFindRegionAndUseGroup){};
 
   SimpleCuboid cuboid;
   double targetedFrequency;
+  int bypassFindRegionAndUseGroup;
 };
 
 class VelocityAwareRefinementSettings {
@@ -35,7 +38,8 @@ class VelocityAwareRefinementSettings {
   VelocityAwareRefinementSettings() = default;
   VelocityAwareRefinementSettings(double elementsPerWaveLength, std::string easiFileName);
 
-  void addRefinementRegion(SimpleCuboid cuboid, double targetedFrequency);
+  void addRefinementRegion(SimpleCuboid cuboid, double targetedFrequency,
+                           int bypassFindRegionAndUseGroup);
 
   [[nodiscard]] bool isVelocityAwareRefinementOn() const;
 


### PR DESCRIPTION
This PR aims at speeding up velocity-aware mesh generation by allowing to bypass the findRegion function (which can be expensive if the geometry is large).
This is done by:
- adding a bypassFindRegionAndUseGroup argument to VelocityRefinementCuboid
- bypassing by default FindRegion if one region only.

Also, this PR incorporates the changes proposed in #37.
