### PR TITLE
up to new api: Sim_readLicenseFile -> SimLicense_start

### DIFF
--- a/cmake/FindSIMMETRIX.cmake
+++ b/cmake/FindSIMMETRIX.cmake
@@ -13,7 +13,8 @@ list(APPEND SIMMETRIX_INCLUDE_DIR
 find_library(GMI_SIM_LIB gmi_sim)
 find_library(APF_SIM_LIB apf_sim)
 
-set(SIM_LIB_HINT ${SIMMETRIX_ROOT}/lib/x64_rhel7_gcc48)
+message(SIMMETRIX_ROOT : ${SIMMETRIX_ROOT})
+set(SIM_LIB_HINT ${SIMMETRIX_ROOT}/lib/x64_rhel8_gcc83)
 
 find_library(SIM_DISCRETE_LIB SimDiscrete ${SIM_LIB_HINT})
 find_library(SIM_MESHING_LIB SimMeshing ${SIM_LIB_HINT})
@@ -26,6 +27,8 @@ find_library(SIM_PARTITIONED_MESH_LIB SimPartitionedMesh ${SIM_LIB_HINT})
 find_library(SIM_PARTITIONED_MESH_MPI_LIB SimPartitionedMesh-mpi ${SIM_LIB_HINT})
 find_library(SIM_PARTITINED_WRAPPER_LIB SimPartitionWrapper-${SIM_MPI} ${SIM_LIB_HINT})
 find_library(SIM_PS_KRNL_LIB pskernel ${SIM_LIB_HINT}/psKrnl)
+find_library(SIM_LICENSE_LIB SimLicense ${SIM_LIB_HINT})
+
   
 get_filename_component(SIM_PS_KRNL_LIB_DIR ${SIM_PS_KRNL_LIB} DIRECTORY)
 
@@ -40,6 +43,7 @@ list(APPEND SIMMETRIX_LIBRARIES
   "${SIM_PARTITINED_WRAPPER_LIB}"
   "${SIM_MODEL_LIB}"
   "${SIM_PS_KRNL_LIB}"
+  "${SIM_LICENSE_LIB}"
 )
 
 if (PARASOLID)
@@ -55,8 +59,15 @@ find_library(TIRPC tirpc)
 if (TIRPC)
     list(APPEND SIMMETRIX_LIBRARIES ${TIRPC})
 endif()
+message(SIM_MODEL_LIB : ${SIM_MODEL_LIB})
 
 string(REGEX REPLACE ".*/([0-9]+).[0-9]-.*" "\\1" SIM_MAJOR_VER ${SIM_MODEL_LIB})
+
+message(SIM_MAJOR_VER : ${SIM_MAJOR_VER})
+message(SIMMETRIX : ${SIMMETRIX})
+message(SIMMETRIX_INCLUDE_DIR : ${SIMMETRIX_INCLUDE_DIR})
+message(SIMMETRIX_LIBRARIES : ${SIMMETRIX_LIBRARIES})
+
 find_package_handle_standard_args(SIMMETRIX DEFAULT_MSG
   SIMMETRIX_INCLUDE_DIR SIMMETRIX_LIBRARIES SIM_MAJOR_VER)
 

--- a/src/input/SimModSuite.h
+++ b/src/input/SimModSuite.h
@@ -32,6 +32,7 @@
 #include <SimErrorCodes.h>
 #include <SimMeshingErrorCodes.h>
 #include <SimModel.h>
+#include <SimLicense.h>
 #include <SimModelerUtil.h>
 #ifdef PARASOLID
 #include <SimParasolidKrnl.h>
@@ -77,7 +78,7 @@ class SimModSuite : public MeshInput {
   bool m_log;
 
   public:
-  SimModSuite(const char* modFile, const char* cadFile = 0L, const char* licenseFile = 0L,
+  SimModSuite(const char* modFile, const char* cadFile = 0L, const char* licenseFile = 0L, const char* features = 0L,
               const char* meshCaseName = "mesh", const char* analysisCaseName = "analysis",
               int enforceSize = 0, const char* xmlFile = 0L, const bool analyseAR = false,
               const char* logFile = 0L) {
@@ -89,7 +90,7 @@ class SimModSuite : public MeshInput {
       Sim_logOn(logFile);
     } else
       m_log = false;
-    Sim_readLicenseFile(licenseFile);
+    SimLicense_start(features, licenseFile);
     MS_init();
     SimDiscrete_start(0);
 #ifdef PARASOLID
@@ -236,6 +237,7 @@ class SimModSuite : public MeshInput {
     Sim_unregisterAllKeys();
     if (m_log)
       Sim_logOff();
+    SimLicense_stop();
     SimPartitionedMesh_stop();
     SimModel_stop();
   }

--- a/src/pumgen.cpp
+++ b/src/pumgen.cpp
@@ -68,6 +68,8 @@ int main(int argc, char* argv[]) {
   args.addOption("vtk", 0, "Dump mesh to VTK files", utils::Args::Required, false);
   args.addOption("license", 'l', "License file (only used by SimModSuite)", utils::Args::Required,
                  false);
+  args.addOption("features", 'f', "SimModSuite features (available in License file, comma unspaced separated)", utils::Args::Required,
+                 false);
 #ifdef PARASOLID
   args.addOption("cad", 'c', "CAD file (only used by SimModSuite)", utils::Args::Required, false);
 #endif
@@ -148,7 +150,8 @@ int main(int argc, char* argv[]) {
 
     meshInput = new SimModSuite(
         inputFile, args.getArgument<const char*>("cad", 0L),
-        args.getArgument<const char*>("license", 0L), args.getArgument<const char*>("mesh", "mesh"),
+        args.getArgument<const char*>("license", 0L), args.getArgument<const char*>("features", 0L), 
+        args.getArgument<const char*>("mesh", "mesh"),
         args.getArgument<const char*>("analysis", "analysis"),
         args.getArgument<int>("enforce-size", 0), args.getArgument<const char*>("xml", 0L),
         args.isSet("analyseAR"), args.getArgument<const char*>("sim_log", 0L));


### PR DESCRIPTION
rebased and cleaned PR. More info is below:

>Effectivement j'ai fait cette modif sur la suggestion du support SimModeler, qui nous informait de l'obsolescence de l'ancienne API.
Mais bizarrement, vous ne semblez pas avoir ce problème pourtant avec la même version que nous... Je n'ai pas d'explication rationnelle à ce point.
(ou alors une possible retro-compatibilité des anciennes compilations, dont je n'ai pas bénéficié car je compilait tout from scratch ?)
>Concernant l'usage de l'option -f (qui devrait d'ailleurs permettre de ne pas bloquer un jeton de licence pour tous les modules à la fois, contrairement à l'ancienne méthode) il faut utiliser les noms complets des modules :
/opt/PUMGen/build/pumgen -s simmodsuite -l /simmodsuite/16.0-220101/simmodsuite.lic -f geomsim_core,geomsim_discrete,geomsim_discretemodeling,meshsim_surface,meshsim_volume,meshsim_parallelmeshing 