### PR TITLE
Towards Large Meshes

### DIFF
--- a/src/input/NetCDFPartition.h
+++ b/src/input/NetCDFPartition.h
@@ -20,8 +20,8 @@
  */
 class Partition {
   private:
-  unsigned int m_nElements;
-  unsigned int m_nVertices;
+  std::size_t m_nElements;
+  std::size_t m_nVertices;
 
   int* m_elements;
   double* m_vertices;
@@ -40,7 +40,7 @@ class Partition {
     delete[] m_groups;
   }
 
-  void setElemSize(unsigned int nElements) {
+  void setElemSize(std::size_t nElements) {
     if (m_nElements != 0)
       return;
 
@@ -53,7 +53,7 @@ class Partition {
     memset(m_groups, 0, nElements * sizeof(int));
   }
 
-  void setVrtxSize(unsigned int nVertices) {
+  void setVrtxSize(std::size_t nVertices) {
     if (m_nVertices != 0)
       return;
 
@@ -72,9 +72,9 @@ class Partition {
     }
   }
 
-  unsigned int nElements() const { return m_nElements; }
+  std::size_t nElements() const { return m_nElements; }
 
-  unsigned int nVertices() const { return m_nVertices; }
+  std::size_t nVertices() const { return m_nVertices; }
 
   int* elements() { return m_elements; }
 

--- a/src/input/ParallelVertexFilter.h
+++ b/src/input/ParallelVertexFilter.h
@@ -22,9 +22,13 @@
 #include <cassert>
 #include <cstdint>
 #include <cstring>
+#include <numeric>
 #include <vector>
+#include <array>
 
 #include "utils/logger.h"
+
+#include "third_party/MPITraits.h"
 
 /**
  * Filters duplicate vertices in parallel
@@ -36,12 +40,12 @@ class ParallelVertexFilter {
    */
   class IndexedVertexComparator {
 private:
-    const double* m_vertices;
+    const std::vector<double>& m_vertices;
 
 public:
-    IndexedVertexComparator(const double* vertices) : m_vertices(vertices) {}
+    IndexedVertexComparator(const std::vector<double>& vertices) : m_vertices(vertices) {}
 
-    bool operator()(unsigned int i, unsigned int j) {
+    bool operator()(std::size_t i, std::size_t j) {
       i *= 3;
       j *= 3;
 
@@ -63,17 +67,17 @@ public:
   int m_numProcs;
 
   /** Global id after filtering */
-  unsigned long* m_globalIds;
+  std::vector<std::size_t> m_globalIds;
 
   /** Number of local vertices after filtering */
-  unsigned int m_numLocalVertices;
+  std::size_t m_numLocalVertices;
 
   /** Local vertices after filtering */
-  double* m_localVertices;
+  std::vector<double> m_localVertices;
 
   public:
   ParallelVertexFilter(MPI_Comm comm = MPI_COMM_WORLD)
-      : m_comm(comm), m_globalIds(0L), m_numLocalVertices(0), m_localVertices(0L) {
+      : m_comm(comm), m_numLocalVertices(0) {
     MPI_Comm_rank(comm, &m_rank);
     MPI_Comm_size(comm, &m_numProcs);
 
@@ -84,25 +88,23 @@ public:
   }
 
   virtual ~ParallelVertexFilter() {
-    delete[] m_globalIds;
-    delete[] m_localVertices;
   }
 
   /**
    * @param vertices Vertices that should be filtered, must have the size
    * <code>numVertices * 3</code>
    */
-  void filter(unsigned int numVertices, const double* vertices) {
+  void filter(std::size_t numVertices, const std::vector<double>& vertices) {
     // Chop the last 4 bits to avoid numerical errors
-    double* roundVertices = new double[numVertices * 3];
-    removeRoundError(vertices, numVertices * 3, roundVertices);
+    std::vector<double> roundVertices (numVertices * 3);
+    removeRoundError(vertices, roundVertices);
 
     // Create indices and sort them locally
-    unsigned int* sortIndices = new unsigned int[numVertices];
-    createSortedIndices(roundVertices, numVertices, sortIndices);
+    std::vector<std::size_t> sortIndices(numVertices);
+    createSortedIndices(roundVertices, sortIndices);
 
     // Select BUCKETS_PER_RANK-1 splitter elements
-    double localSplitters[BUCKETS_PER_RANK - 1];
+    std::array<double, BUCKETS_PER_RANK - 1> localSplitters;
 #if 0 // Use omp only if we create a larger amount of buckets
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
@@ -118,20 +120,22 @@ public:
     }
 
     // Collect all splitter elements on rank 0
-    double* allSplitters = 0L;
+    std::vector<double> allSplitters;
 
-    if (m_rank == 0)
-      allSplitters = new double[m_numProcs * (BUCKETS_PER_RANK - 1)];
+    if (m_rank == 0) {
+      allSplitters.resize(m_numProcs * (BUCKETS_PER_RANK - 1));
+    }
 
-    MPI_Gather(localSplitters, BUCKETS_PER_RANK - 1, MPI_DOUBLE, allSplitters, BUCKETS_PER_RANK - 1,
+    MPI_Gather(localSplitters.data(), BUCKETS_PER_RANK - 1, MPI_DOUBLE, allSplitters.data(), BUCKETS_PER_RANK - 1,
                MPI_DOUBLE, 0, m_comm);
 
     // Sort splitter elements
-    if (m_rank == 0)
-      std::sort(allSplitters, allSplitters + (m_numProcs * (BUCKETS_PER_RANK - 1)));
+    if (m_rank == 0) {
+      std::sort(allSplitters.begin(), allSplitters.end());
+    }
 
     // Distribute splitter to all processes
-    double* splitters = new double[m_numProcs - 1];
+    std::vector<double> splitters (m_numProcs - 1);
 
     if (m_rank == 0) {
 #ifdef _OPENMP
@@ -145,157 +149,142 @@ public:
       }
     }
 
-    MPI_Bcast(splitters, m_numProcs - 1, MPI_DOUBLE, 0, m_comm);
-
-    delete[] allSplitters;
+    MPI_Bcast(splitters.data(), m_numProcs - 1, MPI_DOUBLE, 0, m_comm);
 
     // Determine the bucket for each vertex
-    unsigned int* bucket = new unsigned int[numVertices];
+    std::vector<std::size_t> bucket (numVertices);
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (unsigned int i = 0; i < numVertices; i++) {
-      double* ub = std::upper_bound(splitters, splitters + m_numProcs - 1, roundVertices[i * 3]);
+    for (std::size_t i = 0; i < numVertices; i++) {
+      auto ub = std::upper_bound(splitters.begin(), splitters.end(), roundVertices[i * 3]);
 
-      bucket[i] = ub - splitters;
+      bucket[i] = std::distance(splitters.begin(), ub);
     }
 
-    delete[] roundVertices;
-    delete[] splitters;
-
     // Determine the (local and total) bucket size
-    int* bucketSize = new int[m_numProcs];
-    memset(bucketSize, 0, sizeof(int) * m_numProcs);
-    for (unsigned int i = 0; i < numVertices; i++)
-      bucketSize[bucket[i]]++;
-
-    delete[] bucket;
+    std::vector<int> bucketSize (m_numProcs);
+    for (std::size_t i = 0; i < numVertices; i++) {
+      ++bucketSize[bucket[i]];
+    }
 
     // Tell all processes what we are going to send them
-    int* recvSize = new int[m_numProcs];
+    std::vector<int> recvSize(m_numProcs);
 
-    MPI_Alltoall(bucketSize, 1, MPI_INT, recvSize, 1, MPI_INT, m_comm);
+    MPI_Alltoall(bucketSize.data(), 1, MPI_INT, recvSize.data(), 1, MPI_INT, m_comm);
 
-    unsigned int numSortVertices = 0;
+    std::size_t numSortVertices = 0;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) reduction(+ : numSortVertices)
 #endif
-    for (int i = 0; i < m_numProcs; i++)
+    for (int i = 0; i < m_numProcs; i++) {
       numSortVertices += recvSize[i];
+    }
 
     // Create sorted send buffer
-    double* sendVertices = new double[3 * numVertices];
+    std::vector<double> sendVertices (3 * numVertices);
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (unsigned int i = 0; i < numVertices; i++) {
-      memcpy(&sendVertices[i * 3], &vertices[sortIndices[i] * 3], sizeof(double) * 3);
+    for (std::size_t i = 0; i < numVertices; i++) {
+      std::copy_n(vertices.begin() + sortIndices[i] * 3, 3, sendVertices.begin() + i * 3);
     }
 
     // Allocate buffer for the vertices and exchange them
-    double* sortVertices = new double[3 * numSortVertices];
+    std::vector<double> sortVertices (3 * numSortVertices);
 
-    int* sDispls = new int[m_numProcs];
-    int* rDispls = new int[m_numProcs];
+    std::vector<int> sDispls (m_numProcs);
+    std::vector<int> rDispls (m_numProcs);
     sDispls[0] = 0;
     rDispls[0] = 0;
     for (int i = 1; i < m_numProcs; i++) {
       sDispls[i] = sDispls[i - 1] + bucketSize[i - 1];
       rDispls[i] = rDispls[i - 1] + recvSize[i - 1];
     }
-    MPI_Alltoallv(sendVertices, bucketSize, sDispls, vertexType, sortVertices, recvSize, rDispls,
+    MPI_Alltoallv(sendVertices.data(), bucketSize.data(), sDispls.data(), vertexType, sortVertices.data(), recvSize.data(), rDispls.data(),
                   vertexType, m_comm);
 
-    delete[] sendVertices;
-
     // Chop the last 4 bits to avoid numerical errors
-    roundVertices = new double[numSortVertices * 3];
-    removeRoundError(sortVertices, numSortVertices * 3, roundVertices);
+    roundVertices.resize(numSortVertices * 3);
+    removeRoundError(sortVertices, roundVertices);
 
     // Create indices and sort them (such that the vertices are sorted)
-    unsigned int* sortSortIndices = new unsigned int[numSortVertices];
-    createSortedIndices(roundVertices, numSortVertices, sortSortIndices);
-
-    delete[] roundVertices;
+    std::vector<std::size_t> sortSortIndices (numSortVertices);
+    createSortedIndices(roundVertices, sortSortIndices);
 
     // Initialize the global ids we send back to the other processors
-    unsigned long* gids = new unsigned long[numSortVertices];
+    std::vector<std::size_t> gids (numSortVertices);
 
     if (numSortVertices > 0) {
       gids[sortSortIndices[0]] = 0;
-      for (unsigned int i = 1; i < numSortVertices; i++) {
+      for (std::size_t i = 1; i < numSortVertices; i++) {
         if (equals(&sortVertices[sortSortIndices[i - 1] * 3],
-                   &sortVertices[sortSortIndices[i] * 3]))
+                   &sortVertices[sortSortIndices[i] * 3])) {
           gids[sortSortIndices[i]] = gids[sortSortIndices[i - 1]];
-        else
+                   }
+        else {
           gids[sortSortIndices[i]] = gids[sortSortIndices[i - 1]] + 1;
+        }
       }
     }
 
     // Create the local vertices list
-    if (numSortVertices > 0)
+    if (numSortVertices > 0) {
       m_numLocalVertices = gids[sortSortIndices[numSortVertices - 1]] + 1;
-    else
+    }
+    else {
       m_numLocalVertices = 0;
-    delete[] m_localVertices;
-    m_localVertices = new double[m_numLocalVertices * 3];
-    for (unsigned int i = 0; i < numSortVertices; i++)
-      memcpy(&m_localVertices[gids[i] * 3], &sortVertices[i * 3], sizeof(double) * 3);
+    }
 
-    delete[] sortVertices;
+    m_localVertices.resize(m_numLocalVertices * 3);
+    for (std::size_t i = 0; i < numSortVertices; i++) {
+      std::copy_n(sortVertices.begin() + i * 3, 3, m_localVertices.begin() + gids[i] * 3);
+    }
 
     // Get the vertices offset
-    unsigned int offset = m_numLocalVertices;
-    MPI_Scan(MPI_IN_PLACE, &offset, 1, MPI_UNSIGNED, MPI_SUM, m_comm);
+    std::size_t offset = m_numLocalVertices;
+    MPI_Scan(MPI_IN_PLACE, &offset, 1, tndm::mpi_type_t<std::size_t>(), MPI_SUM, m_comm);
     offset -= m_numLocalVertices;
 
     // Add offset to the global ids
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (unsigned int i = 0; i < numSortVertices; i++)
+    for (std::size_t i = 0; i < numSortVertices; i++) {
       gids[i] += offset;
+    }
 
     // Send result back
-    unsigned long* globalIds = new unsigned long[numVertices];
-    MPI_Alltoallv(gids, recvSize, rDispls, MPI_UNSIGNED_LONG, globalIds, bucketSize, sDispls,
-                  MPI_UNSIGNED_LONG, m_comm);
-
-    delete[] bucketSize;
-    delete[] recvSize;
-    delete[] sDispls;
-    delete[] rDispls;
-    delete[] gids;
+    std::vector<std::size_t> globalIds (numVertices);
+    MPI_Alltoallv(gids.data(), recvSize.data(), rDispls.data(), tndm::mpi_type_t<std::size_t>(), globalIds.data(), bucketSize.data(), sDispls.data(),
+                  tndm::mpi_type_t<std::size_t>(), m_comm);
 
     // Assign the global ids to the correct vertices
-    delete[] m_globalIds;
-    m_globalIds = new unsigned long[numVertices];
+    m_globalIds.resize(numVertices);
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (unsigned int i = 0; i < numVertices; i++)
+    for (std::size_t i = 0; i < numVertices; i++) {
       m_globalIds[sortIndices[i]] = globalIds[i];
-
-    delete[] sortIndices;
-    delete[] globalIds;
+    }
   }
 
   /**
    * @return The list of the global identifiers after filtering
    */
-  const unsigned long* globalIds() const { return m_globalIds; }
+  const std::vector<std::size_t>& globalIds() const { return m_globalIds; }
 
   /**
    * @return Number of vertices this process is responsible for after filtering
    */
-  unsigned int numLocalVertices() const { return m_numLocalVertices; }
+  std::size_t numLocalVertices() const { return m_numLocalVertices; }
 
   /**
    * @return The list of vertices this process is responsible for after
    * filtering
    */
-  const double* localVertices() const { return m_localVertices; }
+  const std::vector<double>& localVertices() const { return m_localVertices; }
 
   private:
   /**
@@ -329,29 +318,33 @@ public:
    * @param[out] roundValues The list of rounded values
    *  (the caller is responsible for allocating the memory)
    */
-  static void removeRoundError(const double* values, unsigned int count, double* roundValues) {
+  static void removeRoundError(const std::vector<double>& values, std::vector<double>& roundValues) {
+    assert(values.size() == roundValues.size());
+
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (unsigned int i = 0; i < count; i++)
+    for (std::size_t i = 0; i < roundValues.size(); i++) {
       roundValues[i] = removeRoundError(values[i]);
+    }
   }
 
   /**
    * Creates the list of sorted indices for the vertices.
    * The caller is responsible for allocating the memory.
    */
-  static void createSortedIndices(const double* vertices, unsigned int numVertices,
-                                  unsigned int* sortedIndices) {
+  static void createSortedIndices(const std::vector<double>& vertices,
+                                  std::vector<std::size_t>& sortedIndices) {
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (unsigned int i = 0; i < numVertices; i++)
+    for (std::size_t i = 0; i < sortedIndices.size(); i++) {
       sortedIndices[i] = i;
+    }
 
     IndexedVertexComparator comparator(vertices);
-    std::sort(sortedIndices, sortedIndices + numVertices, comparator);
+    std::sort(sortedIndices.begin(), sortedIndices.end(), comparator);
   }
 
   /**
@@ -366,7 +359,7 @@ public:
   static MPI_Datatype vertexType;
 
   /** The total buckets we create is <code>BUCKETS_PER_RANK * numProcs</code> */
-  const static int BUCKETS_PER_RANK = 8;
+  constexpr static int BUCKETS_PER_RANK = 8;
 };
 
 #endif // PARALLEL_VERTEX_FILTER_H

--- a/src/input/SerialMeshFile.h
+++ b/src/input/SerialMeshFile.h
@@ -71,10 +71,10 @@ template <typename T> class SerialMeshFile : public MeshInput {
   void open(const char* meshFile) {
     m_meshReader.open(meshFile);
 
-    unsigned int nVertices = m_meshReader.nVertices();
-    unsigned int nElements = m_meshReader.nElements();
-    unsigned int nLocalVertices = (nVertices + m_nProcs - 1) / m_nProcs;
-    unsigned int nLocalElements = (nElements + m_nProcs - 1) / m_nProcs;
+    const std::size_t nVertices = m_meshReader.nVertices();
+    const std::size_t nElements = m_meshReader.nElements();
+    std::size_t nLocalVertices = (nVertices + m_nProcs - 1) / m_nProcs;
+    std::size_t nLocalElements = (nElements + m_nProcs - 1) / m_nProcs;
     if (m_rank == m_nProcs - 1) {
       nLocalVertices = nVertices - (m_nProcs - 1) * nLocalVertices;
       nLocalElements = nElements - (m_nProcs - 1) * nLocalElements;
@@ -89,7 +89,7 @@ template <typename T> class SerialMeshFile : public MeshInput {
     {
       std::vector<ElementID> elements;
       {
-        std::vector<int> elementsInt(nLocalElements * 4);
+        std::vector<std::size_t> elementsInt(nLocalElements * 4);
         m_meshReader.readElements(elementsInt.data());
         elements = std::vector<ElementID>(elementsInt.begin(), elementsInt.end());
       }
@@ -114,12 +114,12 @@ template <typename T> class SerialMeshFile : public MeshInput {
       std::vector<int> boundaries(nLocalElements * 4);
       m_meshReader.readBoundaries(boundaries.data());
       apf::MeshIterator* it = m_mesh->begin(3);
-      unsigned int i = 0;
+      std::size_t i = 0;
       while (apf::MeshEntity* element = m_mesh->iterate(it)) {
         apf::Adjacent adjacent;
         m_mesh->getAdjacent(element, 2, adjacent);
 
-        for (unsigned int j = 0; j < 4; j++) {
+        for (int j = 0; j < 4; j++) {
           if (!boundaries[i * 4 + j]) {
             continue;
           }
@@ -138,7 +138,7 @@ template <typename T> class SerialMeshFile : public MeshInput {
       std::vector<int> groups(nLocalElements);
       m_meshReader.readGroups(groups.data());
       apf::MeshIterator* it = m_mesh->begin(3);
-      unsigned int i = 0;
+      std::size_t i = 0;
       while (apf::MeshEntity* element = m_mesh->iterate(it)) {
         m_mesh->setIntTag(element, groupTag, &groups[i]);
         i++;

--- a/src/meshreader/FidapReader.h
+++ b/src/meshreader/FidapReader.h
@@ -18,6 +18,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <array>
 
 #include "utils/stringutils.h"
 
@@ -25,7 +26,7 @@
 
 struct FidapBoundaryFace {
   /** The vertices of the face */
-  int vertices[3];
+  std::array<std::size_t, 3> vertices;
   /** The type of the boundary */
   int type;
 };
@@ -34,16 +35,16 @@ struct FidapBoundaryFace {
 struct FaceVertex {
   FaceVertex() {}
 
-  FaceVertex(int v1, int v2, int v3) {
+  FaceVertex(std::size_t v1, std::size_t v2, std::size_t v3) {
     vertices[0] = v1;
     vertices[1] = v2;
     vertices[2] = v3;
-    std::sort(vertices, vertices + 3);
+    std::sort(vertices.begin(), vertices.end());
   }
 
-  FaceVertex(const int v[3]) {
-    memcpy(vertices, v, sizeof(vertices));
-    std::sort(vertices, vertices + 3);
+  FaceVertex(const std::array<std::size_t, 3>& v) {
+    std::copy(v.begin(), v.end(), vertices.begin());
+    std::sort(vertices.begin(), vertices.end());
   }
 
   bool operator<(const FaceVertex& other) const {
@@ -53,7 +54,7 @@ struct FaceVertex {
             vertices[2] < other.vertices[2]);
   }
 
-  int vertices[3];
+  std::array<std::size_t, 3> vertices;
 };
 
 /** Defines a face by element and face side */
@@ -63,12 +64,12 @@ struct FaceElement {
     side = -1;
   }
 
-  FaceElement(int e, int s) {
+  FaceElement(std::size_t e, int s) {
     element = e;
     side = s;
   }
 
-  int element;
+  std::size_t element;
   int side;
 };
 
@@ -109,7 +110,7 @@ class FidapReader : public MeshReader {
     getline(m_mesh, line); // Date
     getline(m_mesh, line); // Empty line
 
-    unsigned int nElements, nZones, t, dimensions;
+    std::size_t nElements, nZones, t, dimensions;
     m_mesh >> m_vertices.nLines;
     m_mesh >> nElements;
     m_mesh >> nZones;
@@ -147,10 +148,10 @@ class FidapReader : public MeshReader {
     if (line.find(ELEMENT_GROUPS) == std::string::npos)
       logError() << "Invalid Fidap format: Element groups expected, found" << line;
 
-    for (unsigned int i = 0; i < nZones; i++) {
+    for (std::size_t i = 0; i < nZones; i++) {
       FileSection sec;
 
-      // Group
+      // Group (unused)
       m_mesh >> name;
       if (name.find(ZONE_GROUP) == std::string::npos)
         logError() << "Invalid Fidap format: Expected group, found" << name;
@@ -167,13 +168,13 @@ class FidapReader : public MeshReader {
         logError() << "Invalid Fidap format: Expected nodes, found" << name;
       unsigned int nodeType;
       m_mesh >> nodeType;
-      // Geometry
+      // Geometry (unused)
       m_mesh >> name;
       if (name.find(ZONE_GEOMETRY) == std::string::npos)
         logError() << "Invalid Fidap format: Expected geometry, found" << name;
       unsigned int geoType;
       m_mesh >> geoType;
-      // Type
+      // Type (unused)
       m_mesh >> name;
       if (name.find(ZONE_TYPE) == std::string::npos)
         logError() << "Invalid Fidap format: Expected type, found" << name;
@@ -223,35 +224,33 @@ class FidapReader : public MeshReader {
     }
   }
 
-  unsigned int nVertices() const { return m_vertices.nLines; }
+  std::size_t nVertices() const { return m_vertices.nLines; }
 
-  unsigned int nElements() const {
-    unsigned int count = 0;
-    for (std::vector<ElementSection>::const_iterator i = m_elements.begin(); i != m_elements.end();
-         i++) {
-      count += i->nLines;
+  std::size_t nElements() const {
+    std::size_t count = 0;
+    for (const auto& element : m_elements) {
+      count += element.nLines;
     }
 
     return count;
   }
 
-  unsigned int nBoundaries() const {
-    unsigned int count = 0;
-    for (std::vector<BoundarySection>::const_iterator i = m_boundaries.begin();
-         i != m_boundaries.end(); i++) {
-      count += i->nLines;
+  std::size_t nBoundaries() const {
+    std::size_t count = 0;
+    for (const auto& boundary : m_boundaries) {
+      count += boundary.nLines;
     }
 
     return count;
   }
 
-  void readVertices(unsigned int start, unsigned int count, double* vertices) {
+  void readVertices(std::size_t start, std::size_t count, double* vertices) {
     m_mesh.clear();
 
     m_mesh.seekg(m_vertices.seekPosition + start * m_vertices.lineSize + m_vertices.lineSize -
                  3 * COORDINATE_SIZE - 1);
 
-    for (unsigned int i = 0; i < count; i++) {
+    for (std::size_t i = 0; i < count; i++) {
       for (int j = 0; j < 3; j++)
         m_mesh >> vertices[i * 3 + j];
 
@@ -259,7 +258,7 @@ class FidapReader : public MeshReader {
     }
   }
 
-  void readElements(unsigned int start, unsigned int count, int* elements) {
+  void readElements(std::size_t start, std::size_t count, std::size_t* elements) {
     m_mesh.clear();
 
     // Get the boundary, were we should start reading
@@ -271,7 +270,7 @@ class FidapReader : public MeshReader {
     m_mesh.seekg(section->seekPosition + start * section->lineSize + section->lineSize -
                  4 * VERTEX_ID_SIZE - 1);
 
-    for (unsigned int i = 0; i < count; i++) {
+    for (std::size_t i = 0; i < count; i++) {
       if (start >= section->nLines) {
         // Are we starting a new section in this iteration?
         start = 0;
@@ -280,7 +279,7 @@ class FidapReader : public MeshReader {
         m_mesh.seekg(section->seekPosition + section->lineSize - 4 * VERTEX_ID_SIZE - 1);
       }
 
-      for (unsigned int j = 0; j < 4; j++) {
+      for (int j = 0; j < 4; j++) {
         m_mesh >> elements[i * 4 + j];
         elements[i * 4 + j]--;
       }
@@ -295,14 +294,14 @@ class FidapReader : public MeshReader {
    * Read group ids from start to start+count. The group ids are sorted
    * in the same order as the elements.
    */
-  void readGroups(unsigned int start, unsigned int count, int* groups) {
+  void readGroups(std::size_t start, std::size_t count, int* groups) {
     // Get the boundary, were we should start reading
     std::vector<ElementSection>::const_iterator section;
     for (section = m_elements.begin(); section != m_elements.end() && section->nLines < start;
          section++)
       start -= section->nLines;
 
-    for (unsigned int i = 0; i < count; i++) {
+    for (std::size_t i = 0; i < count; i++) {
       if (start >= section->nLines) {
         // Are we starting a new section in this iteration?
         start = 0;
@@ -320,7 +319,7 @@ class FidapReader : public MeshReader {
    */
   void readGroups(int* groups) { readGroups(0, nElements(), groups); }
 
-  void readBoundaries(unsigned int start, unsigned int count, FidapBoundaryFace* boundaries) {
+  void readBoundaries(std::size_t start, std::size_t count, FidapBoundaryFace* boundaries) {
     m_mesh.clear();
 
     // Get the boundary, were we should start reading
@@ -332,7 +331,7 @@ class FidapReader : public MeshReader {
     m_mesh.seekg(section->seekPosition + start * section->lineSize + section->lineSize -
                  3 * VERTEX_ID_SIZE - 1);
 
-    for (unsigned int i = 0; i < count; i++) {
+    for (std::size_t i = 0; i < count; i++) {
       if (start >= section->nLines) {
         // Are we starting a new section in this iteration?
         start = 0;
@@ -341,7 +340,7 @@ class FidapReader : public MeshReader {
         m_mesh.seekg(section->seekPosition + section->lineSize - 3 * VERTEX_ID_SIZE - 1);
       }
 
-      for (unsigned int j = 0; j < 3; j++) {
+      for (int j = 0; j < 3; j++) {
         m_mesh >> boundaries[i].vertices[j];
         boundaries[i].vertices[j]--;
       }
@@ -354,7 +353,7 @@ class FidapReader : public MeshReader {
     }
   }
 
-  // TODO void readBoundaries(int* boundaries) {}
+  // TODO void readBoundaries(std::size_t* boundaries) {}
 
   public:
   /**
@@ -364,9 +363,9 @@ class FidapReader : public MeshReader {
    * @param n Number of elements
    * @param[out] map The map
    */
-  static void createFaceMap(const int* elements, unsigned int n,
+  static void createFaceMap(const std::size_t* elements, std::size_t n,
                             std::map<FaceVertex, FaceElement>& map) {
-    for (unsigned int i = 0; i < n; i++) {
+    for (std::size_t i = 0; i < n; i++) {
       FaceVertex v1(elements[i * 4], elements[i * 4 + 1], elements[i * 4 + 2]);
       FaceElement e1(i, 0);
       map[v1] = e1;

--- a/src/meshreader/FidapReader.h
+++ b/src/meshreader/FidapReader.h
@@ -14,11 +14,11 @@
 #define FIDAP_READER_H
 
 #include <algorithm>
+#include <array>
 #include <map>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <array>
 
 #include "utils/stringutils.h"
 

--- a/src/meshreader/GMSHBuilder.h
+++ b/src/meshreader/GMSHBuilder.h
@@ -18,7 +18,7 @@ template <> struct GMSHSimplexType<3u> { static constexpr long type = 4; };  // 
 template <std::size_t D> class GMSHBuilder : public tndm::GMSHMeshBuilder {
   public:
   using vertex_t = std::array<double, D>;
-  using element_t = std::array<int, D + 1u>;
+  using element_t = std::array<std::size_t, D + 1u>;
   using facet_t = std::array<int, D>;
 
   std::vector<vertex_t> vertices;

--- a/src/meshreader/GMSHBuilder.h
+++ b/src/meshreader/GMSHBuilder.h
@@ -10,6 +10,9 @@
 namespace puml {
 
 template <std::size_t D> struct GMSHSimplexType {};
+
+// clang format seems to mess up the following lines from time to time, hence we disable it
+// clang-format off
 template <> struct GMSHSimplexType<0u> {
   static constexpr long type = 15;
 }; // 15 -> point
@@ -22,6 +25,7 @@ template <> struct GMSHSimplexType<2u> {
 template <> struct GMSHSimplexType<3u> {
   static constexpr long type = 4;
 }; // 4 -> tetrahedron
+// clang-format on
 
 template <std::size_t D> class GMSHBuilder : public tndm::GMSHMeshBuilder {
   public:

--- a/src/meshreader/GMSHBuilder.h
+++ b/src/meshreader/GMSHBuilder.h
@@ -10,10 +10,18 @@
 namespace puml {
 
 template <std::size_t D> struct GMSHSimplexType {};
-template <> struct GMSHSimplexType<0u> { static constexpr long type = 15; }; // 15 -> point
-template <> struct GMSHSimplexType<1u> { static constexpr long type = 1; };  // 1 -> line
-template <> struct GMSHSimplexType<2u> { static constexpr long type = 2; };  // 2 -> triangle
-template <> struct GMSHSimplexType<3u> { static constexpr long type = 4; };  // 4 -> tetrahedron
+template <> struct GMSHSimplexType<0u> {
+  static constexpr long type = 15;
+}; // 15 -> point
+template <> struct GMSHSimplexType<1u> {
+  static constexpr long type = 1;
+}; // 1 -> line
+template <> struct GMSHSimplexType<2u> {
+  static constexpr long type = 2;
+}; // 2 -> triangle
+template <> struct GMSHSimplexType<3u> {
+  static constexpr long type = 4;
+}; // 4 -> tetrahedron
 
 template <std::size_t D> class GMSHBuilder : public tndm::GMSHMeshBuilder {
   public:

--- a/src/meshreader/GambitReader.h
+++ b/src/meshreader/GambitReader.h
@@ -302,7 +302,7 @@ class GambitReader : public MeshReader {
     m_mesh.seekg(m_vertices.seekPosition + start * m_vertices.lineSize + m_vertices.lineSize -
                  3 * COORDINATE_SIZE - 1);
 
-    std::vector<char> buf(3* COORDINATE_SIZE);
+    std::vector<char> buf(3 * COORDINATE_SIZE);
 
     for (std::size_t i = 0; i < count; i++) {
       m_mesh.read(buf.data(), 3 * COORDINATE_SIZE);
@@ -444,8 +444,7 @@ class GambitReader : public MeshReader {
 
         if (section->variableLineLength) {
           buf.resize(0);
-        }
-        else {
+        } else {
           buf.resize(section->elementSize + section->elementTypeSize + section->faceSize);
         }
       }
@@ -456,13 +455,15 @@ class GambitReader : public MeshReader {
         m_mesh >> elementType;
         m_mesh >> boundaries[i].face;
       } else {
-        m_mesh.read(buf.data(), section->elementSize + section->elementTypeSize + section->faceSize);
+        m_mesh.read(buf.data(),
+                    section->elementSize + section->elementTypeSize + section->faceSize);
 
         std::istringstream ssE(std::string(buf.begin(), buf.begin() + section->elementSize));
         ssE >> boundaries[i].element;
 
-        std::istringstream ssF(
-            std::string(buf.begin() + section->elementSize + section->elementTypeSize, buf.begin() + section->elementSize + section->elementTypeSize + section->faceSize));
+        std::istringstream ssF(std::string(
+            buf.begin() + section->elementSize + section->elementTypeSize,
+            buf.begin() + section->elementSize + section->elementTypeSize + section->faceSize));
         ssF >> boundaries[i].face;
 
         // Seek to next position

--- a/src/meshreader/GambitReader.h
+++ b/src/meshreader/GambitReader.h
@@ -30,7 +30,7 @@ namespace puml {
  */
 struct ElementGroup {
   /** The element */
-  unsigned int element;
+  std::size_t element;
   /** The group for this element */
   int group;
 };
@@ -40,7 +40,7 @@ struct ElementGroup {
  */
 struct GambitBoundaryFace {
   /** The element the face belongs to */
-  unsigned int element;
+  std::size_t element;
   /** The face of the element */
   unsigned int face;
   /** The type of the boundary */
@@ -107,7 +107,7 @@ class GambitReader : public MeshReader {
 
     getline(m_mesh, line); // Skip problem size names
 
-    unsigned int nGroups, nBoundaries, dimensions;
+    std::size_t nGroups, nBoundaries, dimensions;
     m_mesh >> m_vertices.nLines;
     m_mesh >> m_elements.nLines;
     m_mesh >> nGroups;
@@ -166,7 +166,7 @@ class GambitReader : public MeshReader {
 
     // Groups
     m_groups.resize(nGroups);
-    for (unsigned int i = 0; i < nGroups; i++) {
+    for (std::size_t i = 0; i < nGroups; i++) {
       getline(m_mesh, line);
       if (line.find(ELEMENT_GROUP) == std::string::npos)
         logError() << "Invalid Gambit format: Group expected, found" << line;
@@ -213,7 +213,7 @@ class GambitReader : public MeshReader {
 
     // Boundaries
     m_boundaries.resize(nBoundaries);
-    for (unsigned int i = 0; i < nBoundaries; i++) {
+    for (std::size_t i = 0; i < nBoundaries; i++) {
       getline(m_mesh, line);
       if (line.find(BOUNDARY_CONDITIONS) == std::string::npos)
         logError() << "Invalid Gambit format: Boundaries expected, found" << line;
@@ -236,7 +236,7 @@ class GambitReader : public MeshReader {
 
       // Get element size
       std::istringstream ssE(line);
-      unsigned int element, type, face;
+      std::size_t element, type, face;
       ssE >> element;
       m_boundaries[i].elementSize = ssE.tellg();
       ssE >> type;
@@ -278,35 +278,34 @@ class GambitReader : public MeshReader {
     }
   }
 
-  unsigned int nVertices() const { return m_vertices.nLines; }
+  std::size_t nVertices() const { return m_vertices.nLines; }
 
-  unsigned int nElements() const { return m_elements.nLines; }
+  std::size_t nElements() const { return m_elements.nLines; }
 
-  unsigned int nBoundaries() const {
-    unsigned int count = 0;
-    for (std::vector<BoundarySection>::const_iterator i = m_boundaries.begin();
-         i != m_boundaries.end(); i++) {
-      count += i->nLines;
+  std::size_t nBoundaries() const {
+    std::size_t count = 0;
+    for (const auto& boundary : m_boundaries) {
+      count += boundary.nLines;
     }
 
     return count;
   }
 
   /**
-   * @copydoc MeshReader::readVertices(unsigned int, unsigned int, double*)
+   * @copydoc MeshReader::readVertices(size_t, size_t, double*)
    *
    * @todo Only 3 dimensional meshes are supported
    */
-  void readVertices(unsigned int start, unsigned int count, double* vertices) {
+  void readVertices(std::size_t start, std::size_t count, double* vertices) {
     m_mesh.clear();
 
     m_mesh.seekg(m_vertices.seekPosition + start * m_vertices.lineSize + m_vertices.lineSize -
                  3 * COORDINATE_SIZE - 1);
 
-    char* buf = new char[3 * COORDINATE_SIZE];
+    std::vector<char> buf(3* COORDINATE_SIZE);
 
-    for (unsigned int i = 0; i < count; i++) {
-      m_mesh.read(buf, 3 * COORDINATE_SIZE);
+    for (std::size_t i = 0; i < count; i++) {
+      m_mesh.read(buf.data(), 3 * COORDINATE_SIZE);
 
       for (int j = 0; j < 3; j++) {
         std::istringstream ss(std::string(&buf[j * COORDINATE_SIZE], COORDINATE_SIZE));
@@ -315,25 +314,23 @@ class GambitReader : public MeshReader {
 
       m_mesh.seekg(m_vertices.lineSize - 3 * COORDINATE_SIZE, std::fstream::cur);
     }
-
-    delete[] buf;
   }
 
   /**
-   * @copydoc MeshReader::readElements(unsigned int, unsigned int, int*)
+   * @copydoc MeshReader::readElements(size_t, size_t, size_t*)
    *
    * @todo Only tetrahedral meshes are supported
    * @todo Support for varying coordinate/vertexid fields
    */
-  void readElements(unsigned int start, unsigned int count, int* elements) {
+  void readElements(std::size_t start, std::size_t count, std::size_t* elements) {
     m_mesh.clear();
 
     m_mesh.seekg(m_elements.seekPosition + start * m_elements.lineSize + m_elements.vertexStart);
 
-    char* buf = new char[4 * m_elements.vertexSize];
+    std::vector<char> buf(4 * m_elements.vertexSize);
 
-    for (unsigned int i = 0; i < count; i++) {
-      m_mesh.read(buf, 4 * m_elements.vertexSize);
+    for (std::size_t i = 0; i < count; i++) {
+      m_mesh.read(buf.data(), 4 * m_elements.vertexSize);
 
       for (int j = 0; j < 4; j++) {
         std::istringstream ss(std::string(&buf[j * m_elements.vertexSize], m_elements.vertexSize));
@@ -343,8 +340,6 @@ class GambitReader : public MeshReader {
 
       m_mesh.seekg(m_elements.lineSize - 4 * m_elements.vertexSize, std::fstream::cur);
     }
-
-    delete[] buf;
   }
 
   /**
@@ -353,24 +348,25 @@ class GambitReader : public MeshReader {
    * @param groups Buffer for storing the group numbers. The caller is
    * responsible for allocating the buffer.
    */
-  void readGroups(unsigned int start, unsigned int count, ElementGroup* groups) {
+  void readGroups(std::size_t start, std::size_t count, ElementGroup* groups) {
     m_mesh.clear();
 
     // Get the group, were we should start reading
     std::vector<GroupSection>::const_iterator section;
     for (section = m_groups.begin(); section != m_groups.end() && section->nLines < start;
-         section++)
+         section++) {
       start -= section->nLines;
+    }
 
     m_mesh.seekg(section->seekPosition + (start / ELEMENTS_PER_LINE_GROUP) * section->lineSize +
                  (start % ELEMENTS_PER_LINE_GROUP) * section->elementSize);
 
-    char* buf = new char[section->elementSize];
+    std::vector<char> buf(section->elementSize);
 
-    for (unsigned int i = 0; i < count; i++) {
-      m_mesh.read(buf, section->elementSize);
+    for (std::size_t i = 0; i < count; i++) {
+      m_mesh.read(buf.data(), section->elementSize);
 
-      std::istringstream ss(std::string(buf, section->elementSize));
+      std::istringstream ss(std::string(buf.begin(), buf.end()));
       ss >> groups[i].element;
       groups[i].element--;
       groups[i].group = section->group;
@@ -387,28 +383,25 @@ class GambitReader : public MeshReader {
         m_mesh.seekg(section->lineSize - section->elementSize * ELEMENTS_PER_LINE_GROUP,
                      std::fstream::cur);
     }
-
-    delete[] buf;
   }
 
   /**
    * Reads all groups numbers.
-   * In contrast to readGroups(unsigned int, unsigned int, ElementGroup*) it
+   * In contrast to readGroups(size_t, size_t, ElementGroup*) it
    * returns the group numbers sorted according to the elements.
    */
   void readGroups(int* groups) {
     logInfo() << "Reading group information";
 
-    ElementGroup* map = new ElementGroup[nElements()];
-    readGroups(0, nElements(), map);
+    std::vector<ElementGroup> map(nElements());
+    readGroups(0, nElements(), map.data());
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (unsigned int i = 0; i < nElements(); i++)
+    for (std::size_t i = 0; i < nElements(); i++) {
       groups[map[i].element] = map[i].group;
-
-    delete[] map;
+    }
   }
 
   /**
@@ -418,7 +411,7 @@ class GambitReader : public MeshReader {
    * @param elements Buffer to store boundaries. Each boundary consists of the
    * element, the face and the boundary type.
    */
-  void readBoundaries(unsigned int start, unsigned int count, GambitBoundaryFace* boundaries) {
+  void readBoundaries(std::size_t start, std::size_t count, GambitBoundaryFace* boundaries) {
     m_mesh.clear();
 
     // Get the boundary, were we should start reading
@@ -427,21 +420,21 @@ class GambitReader : public MeshReader {
          section++)
       start -= section->nLines;
 
-    char* buf;
+    std::vector<char> buf;
 
     if (section->variableLineLength) {
       m_mesh.seekg(section->seekPosition);
       for (size_t i = 0; i < start; i++)
         m_mesh.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
-      buf = 0L;
+      buf.resize(0);
     } else {
       m_mesh.seekg(section->seekPosition + start * section->lineSize);
 
-      buf = new char[section->elementSize + section->elementTypeSize + section->faceSize];
+      buf.resize(section->elementSize + section->elementTypeSize + section->faceSize);
     }
 
-    for (unsigned int i = 0; i < count; i++) {
+    for (std::size_t i = 0; i < count; i++) {
       if (start >= section->nLines) {
         // Are we starting a new section in this iteration?
         start = 0;
@@ -449,11 +442,12 @@ class GambitReader : public MeshReader {
 
         m_mesh.seekg(section->seekPosition);
 
-        delete[] buf;
-        if (section->variableLineLength)
-          buf = 0L;
-        else
-          buf = new char[section->elementSize + section->elementTypeSize + section->faceSize];
+        if (section->variableLineLength) {
+          buf.resize(0);
+        }
+        else {
+          buf.resize(section->elementSize + section->elementTypeSize + section->faceSize);
+        }
       }
 
       if (section->variableLineLength) {
@@ -462,13 +456,13 @@ class GambitReader : public MeshReader {
         m_mesh >> elementType;
         m_mesh >> boundaries[i].face;
       } else {
-        m_mesh.read(buf, section->elementSize + section->elementTypeSize + section->faceSize);
+        m_mesh.read(buf.data(), section->elementSize + section->elementTypeSize + section->faceSize);
 
-        std::istringstream ssE(std::string(buf, section->elementSize));
+        std::istringstream ssE(std::string(buf.begin(), buf.begin() + section->elementSize));
         ssE >> boundaries[i].element;
 
         std::istringstream ssF(
-            std::string(&buf[section->elementSize + section->elementTypeSize], section->faceSize));
+            std::string(buf.begin() + section->elementSize + section->elementTypeSize, buf.begin() + section->elementSize + section->elementTypeSize + section->faceSize));
         ssF >> boundaries[i].face;
 
         // Seek to next position
@@ -481,10 +475,8 @@ class GambitReader : public MeshReader {
       boundaries[i].face--;
       boundaries[i].type = section->type;
 
-      start++; // Line in the current section
+      ++start; // Line in the current section
     }
-
-    delete[] buf;
   }
 
   /**
@@ -499,14 +491,13 @@ class GambitReader : public MeshReader {
   void readBoundaries(int* boundaries) {
     logInfo() << "Reading boundary conditions";
 
-    unsigned int nBnds = nBoundaries();
-    GambitBoundaryFace* faces = new GambitBoundaryFace[nBoundaries()];
-    readBoundaries(0, nBnds, faces);
+    std::size_t nBnds = nBoundaries();
+    std::vector<GambitBoundaryFace> faces(nBnds);
+    readBoundaries(0, nBnds, faces.data());
 
-    for (unsigned int i = 0; i < nBnds; i++)
+    for (std::size_t i = 0; i < nBnds; i++) {
       boundaries[faces[i].element * 4 + faces[i].face] = faces[i].type;
-
-    delete[] faces;
+    }
   }
 
   private:

--- a/src/meshreader/MeshReader.h
+++ b/src/meshreader/MeshReader.h
@@ -23,7 +23,7 @@ class MeshReader {
     /** Start of the section */
     size_t seekPosition;
     /** Number of elements (lines) in the section */
-    unsigned int nLines;
+    std::size_t nLines;
     /** Line size */
     size_t lineSize;
   };
@@ -45,12 +45,12 @@ class MeshReader {
       logError() << "Could not open mesh file" << meshFile;
   }
 
-  virtual unsigned int nVertices() const = 0;
-  virtual unsigned int nElements() const = 0;
+  virtual std::size_t nVertices() const = 0;
+  virtual std::size_t nElements() const = 0;
   /**
    * @return Number of boundary faces
    */
-  virtual unsigned int nBoundaries() const = 0;
+  virtual std::size_t nBoundaries() const = 0;
 
   /**
    * Reads vertices from start tp start+count from the file and stores them in
@@ -60,12 +60,12 @@ class MeshReader {
    * responsible for allocating the buffer. The size of the buffer must be
    * count*dimensions
    */
-  virtual void readVertices(unsigned int start, unsigned int count, double* vertices) = 0;
+  virtual void readVertices(std::size_t start, std::size_t count, double* vertices) = 0;
 
   /**
    * Read all vertices
    *
-   * @see readVertices(unsigned int, unsigned int, double*)
+   * @see readVertices(size_t, size_t, double*)
    */
   void readVertices(double* vertices) {
     logInfo() << "Reading vertices";
@@ -80,14 +80,14 @@ class MeshReader {
    * responsible for allocating the buffer. The Size of the buffer must be
    * count*vertices_per_element.
    */
-  virtual void readElements(unsigned int start, unsigned int count, int* elements) = 0;
+  virtual void readElements(std::size_t start, std::size_t count, std::size_t* elements) = 0;
 
   /**
    * Reads all elements
    *
-   * @see readElements(unsigned int, unsigned int, unsinged int*)
+   * @see readElements(size_t, size_t, size_t*)
    */
-  void readElements(int* elements) {
+  void readElements(std::size_t* elements) {
     logInfo() << "Reading elements";
     readElements(0, nElements(), elements);
   }

--- a/src/meshreader/ParallelFidapReader.h
+++ b/src/meshreader/ParallelFidapReader.h
@@ -161,7 +161,8 @@ class ParallelFidapReader : public ParallelMeshReader<FidapReader> {
             // Face for another processor
             // Serials the struct to make sending easier
             int proc = v.vertices[1] / vertexChunk;
-            aggregator[proc - 1].insert(aggregator[proc - 1].end(), v.vertices.begin(), v.vertices.end());
+            aggregator[proc - 1].insert(aggregator[proc - 1].end(), v.vertices.begin(),
+                                        v.vertices.end());
             aggregator[proc - 1].push_back(faces[j].type);
           }
         }
@@ -172,7 +173,8 @@ class ParallelFidapReader : public ParallelMeshReader<FidapReader> {
             continue;
 
           sizes[j] = aggregator[j].size() / 4; // 3 vertices + face type
-          MPI_Isend(&sizes[j], 1, tndm::mpi_type_t<std::size_t>(), j + 1, 0, m_comm, &requests[j * 2]);
+          MPI_Isend(&sizes[j], 1, tndm::mpi_type_t<std::size_t>(), j + 1, 0, m_comm,
+                    &requests[j * 2]);
           MPI_Isend(&aggregator[j][0], aggregator[j].size(), MPI_INT, j + 1, 0, m_comm,
                     &requests[j * 2 + 1]);
         }
@@ -200,10 +202,11 @@ class ParallelFidapReader : public ParallelMeshReader<FidapReader> {
           // Finished
           break;
 
-        MPI_Recv(buf.data(), size * 4, tndm::mpi_type_t<std::size_t>(), 0, 0, m_comm, MPI_STATUS_IGNORE);
+        MPI_Recv(buf.data(), size * 4, tndm::mpi_type_t<std::size_t>(), 0, 0, m_comm,
+                 MPI_STATUS_IGNORE);
 
         for (std::size_t i = 0; i < size * 4; i += 4) {
-          FaceVertex v(buf[i], buf[i+1], buf[i+2]);
+          FaceVertex v(buf[i], buf[i + 1], buf[i + 2]);
           facePos.push_back(m_faceMap.at(v));
           faceType.push_back(buf[i + 3]);
         }

--- a/src/meshreader/ParallelFidapReader.h
+++ b/src/meshreader/ParallelFidapReader.h
@@ -19,6 +19,7 @@
 
 #include "FidapReader.h"
 #include "ParallelMeshReader.h"
+#include "third_party/MPITraits.h"
 
 class ParallelFidapReader : public ParallelMeshReader<FidapReader> {
   private:
@@ -31,30 +32,32 @@ class ParallelFidapReader : public ParallelMeshReader<FidapReader> {
   ParallelFidapReader(const char* meshFile, MPI_Comm comm = MPI_COMM_WORLD)
       : ParallelMeshReader<FidapReader>(meshFile, comm) {}
 
-  void readElements(int* elements) {
+  void readElements(std::size_t* elements) {
     ParallelMeshReader<FidapReader>::readElements(elements);
 
     // Create the face map
-    unsigned int chunkSize = (nElements() + m_nProcs - 1) / m_nProcs;
-    unsigned int maxChunkSize = chunkSize;
-    if (m_rank == m_nProcs - 1)
+    std::size_t chunkSize = (nElements() + m_nProcs - 1) / m_nProcs;
+    const std::size_t maxChunkSize = chunkSize;
+    if (m_rank == m_nProcs - 1) {
       chunkSize = nElements() - (m_nProcs - 1) * chunkSize;
+    }
 
     FidapReader::createFaceMap(elements, chunkSize, m_faceMap);
-    for (std::map<FaceVertex, FaceElement>::iterator i = m_faceMap.begin(); i != m_faceMap.end();
-         i++)
-      i->second.element += m_rank * maxChunkSize;
+    for (auto& face : m_faceMap) {
+      face.second.element += m_rank * maxChunkSize;
+    }
   }
 
   /**
    * @copydoc ParallelGambitReader::readGroups
    */
   void readGroups(int* groups) {
-    unsigned int chunkSize = (nElements() + m_nProcs - 1) / m_nProcs;
+    std::size_t chunkSize = (nElements() + m_nProcs - 1) / m_nProcs;
 
     if (m_rank == 0) {
       // Allocate second buffer so we can read and send in parallel
-      int* groups2 = new int[chunkSize];
+      std::vector<int> tempGroups(chunkSize);
+      int* groups2 = tempGroups.data();
       if (m_nProcs % 2 == 0)
         // swap once so we have the correct buffer at the end
         swap(groups, groups2);
@@ -71,7 +74,7 @@ class ParallelFidapReader : public ParallelMeshReader<FidapReader> {
 
       if (m_nProcs > 1) {
         // Read last one
-        unsigned int lastChunkSize = nElements() - (m_nProcs - 1) * chunkSize;
+        const std::size_t lastChunkSize = nElements() - (m_nProcs - 1) * chunkSize;
         logInfo() << "Reading group information part" << (m_nProcs - 1) << "of" << m_nProcs;
         m_serialReader.readGroups((m_nProcs - 1) * chunkSize, lastChunkSize, groups);
         MPI_Wait(&request, MPI_STATUS_IGNORE);
@@ -83,8 +86,6 @@ class ParallelFidapReader : public ParallelMeshReader<FidapReader> {
       logInfo() << "Reading group information part" << m_nProcs << "of" << m_nProcs;
       m_serialReader.readGroups(0, chunkSize, groups);
       MPI_Wait(&request, MPI_STATUS_IGNORE);
-
-      delete[] groups2;
     } else {
       if (m_rank == m_nProcs - 1)
         chunkSize = nElements() - (m_nProcs - 1) * chunkSize;
@@ -123,36 +124,34 @@ class ParallelFidapReader : public ParallelMeshReader<FidapReader> {
     std::vector<FaceElement> facePos;
     std::vector<int> faceType;
 
-    unsigned int chunkSize = (nElements() + m_nProcs - 1) / m_nProcs;
-    unsigned int maxChunkSize = chunkSize;
+    std::size_t chunkSize = (nElements() + m_nProcs - 1) / m_nProcs;
+    const std::size_t maxChunkSize = chunkSize;
 
     if (m_rank == 0) {
-      FidapBoundaryFace* faces = new FidapBoundaryFace[maxChunkSize];
+      std::vector<FidapBoundaryFace> faces(maxChunkSize);
 
-      std::vector<int>* aggregator = new std::vector<int>[m_nProcs - 1];
-      unsigned int* sizes = new unsigned int[m_nProcs - 1];
-      MPI_Request* requests = new MPI_Request[(m_nProcs - 1) * 2];
-      for (int i = 0; i < m_nProcs - 1; i++) {
-        requests[i * 2] = MPI_REQUEST_NULL;
-        requests[i * 2 + 1] = MPI_REQUEST_NULL;
-      }
+      std::vector<std::vector<int>> aggregator(m_nProcs - 1);
+      std::vector<std::size_t> sizes(m_nProcs - 1);
+      std::vector<MPI_Request> requests((m_nProcs - 1) * 2, MPI_REQUEST_NULL);
 
-      unsigned int nChunks = (nBoundaries() + chunkSize - 1) / chunkSize;
-      for (unsigned int i = 0; i < nChunks; i++) {
+      const std::size_t nChunks = (nBoundaries() + chunkSize - 1) / chunkSize;
+      for (std::size_t i = 0; i < nChunks; i++) {
         logInfo() << "Reading boundary conditions part" << (i + 1) << "of" << nChunks;
 
-        if (i == nChunks - 1)
+        if (i == nChunks - 1) {
           chunkSize = nBoundaries() - (nChunks - 1) * chunkSize;
+        }
 
-        m_serialReader.readBoundaries(i * maxChunkSize, chunkSize, faces);
+        m_serialReader.readBoundaries(i * maxChunkSize, chunkSize, faces.data());
 
         // Wait for all sending from last iteration
-        MPI_Waitall((m_nProcs - 1) * 2, requests, MPI_STATUSES_IGNORE);
-        for (int j = 0; j < m_nProcs - 1; j++)
+        MPI_Waitall((m_nProcs - 1) * 2, requests.data(), MPI_STATUSES_IGNORE);
+        for (int j = 0; j < m_nProcs - 1; j++) {
           aggregator[j].clear();
+        }
 
         // Sort boundary conditions into the corresponding aggregator
-        for (unsigned int j = 0; j < chunkSize; j++) {
+        for (std::size_t j = 0; j < chunkSize; j++) {
           FaceVertex v(faces[j].vertices);
 
           if (v.vertices[1] < vertexChunk) {
@@ -161,8 +160,8 @@ class ParallelFidapReader : public ParallelMeshReader<FidapReader> {
           } else {
             // Face for another processor
             // Serials the struct to make sending easier
-            unsigned int proc = v.vertices[1] / vertexChunk;
-            aggregator[proc - 1].insert(aggregator[proc - 1].end(), v.vertices, v.vertices + 3);
+            int proc = v.vertices[1] / vertexChunk;
+            aggregator[proc - 1].insert(aggregator[proc - 1].end(), v.vertices.begin(), v.vertices.end());
             aggregator[proc - 1].push_back(faces[j].type);
           }
         }
@@ -173,54 +172,47 @@ class ParallelFidapReader : public ParallelMeshReader<FidapReader> {
             continue;
 
           sizes[j] = aggregator[j].size() / 4; // 3 vertices + face type
-          MPI_Isend(&sizes[j], 1, MPI_UNSIGNED, j + 1, 0, m_comm, &requests[j * 2]);
+          MPI_Isend(&sizes[j], 1, tndm::mpi_type_t<std::size_t>(), j + 1, 0, m_comm, &requests[j * 2]);
           MPI_Isend(&aggregator[j][0], aggregator[j].size(), MPI_INT, j + 1, 0, m_comm,
                     &requests[j * 2 + 1]);
         }
       }
 
-      MPI_Waitall((m_nProcs - 1) * 2, requests, MPI_STATUSES_IGNORE);
-
-      delete[] faces;
-      delete[] aggregator;
+      MPI_Waitall((m_nProcs - 1) * 2, requests.data(), MPI_STATUSES_IGNORE);
 
       // Send finish signal to all other processes
-      memset(sizes, 0, (m_nProcs - 1) * sizeof(unsigned int));
-      for (int i = 0; i < m_nProcs - 1; i++)
-        MPI_Isend(&sizes[i], 1, MPI_UNSIGNED, i + 1, 0, m_comm, &requests[i]);
-      MPI_Waitall(m_nProcs - 1, requests, MPI_STATUSES_IGNORE);
-
-      delete[] sizes;
-      delete[] requests;
+      std::fill(sizes.begin(), sizes.end(), 0);
+      for (int i = 0; i < m_nProcs - 1; i++) {
+        MPI_Isend(&sizes[i], 1, tndm::mpi_type_t<std::size_t>(), i + 1, 0, m_comm, &requests[i]);
+      }
+      MPI_Waitall(m_nProcs - 1, requests.data(), MPI_STATUSES_IGNORE);
     } else {
       if (m_rank == m_nProcs - 1)
         chunkSize = nElements() - (m_nProcs - 1) * chunkSize;
 
       // Allocate enough memory
-      int* buf = new int[chunkSize * 4];
+      std::vector<std::size_t> buf(chunkSize * 4);
 
       while (true) {
-        unsigned int size;
-        MPI_Recv(&size, 1, MPI_UNSIGNED, 0, 0, m_comm, MPI_STATUS_IGNORE);
+        std::size_t size;
+        MPI_Recv(&size, 1, tndm::mpi_type_t<std::size_t>(), 0, 0, m_comm, MPI_STATUS_IGNORE);
         if (size == 0)
           // Finished
           break;
 
-        MPI_Recv(buf, size * 4, MPI_INT, 0, 0, m_comm, MPI_STATUS_IGNORE);
+        MPI_Recv(buf.data(), size * 4, tndm::mpi_type_t<std::size_t>(), 0, 0, m_comm, MPI_STATUS_IGNORE);
 
-        for (unsigned int i = 0; i < size * 4; i += 4) {
-          FaceVertex v(&buf[i]);
+        for (std::size_t i = 0; i < size * 4; i += 4) {
+          FaceVertex v(buf[i], buf[i+1], buf[i+2]);
           facePos.push_back(m_faceMap.at(v));
           faceType.push_back(buf[i + 3]);
         }
       }
-
-      delete[] buf;
     }
 
     // Distribute the faces to the final ranks
     PCU_Comm_Begin();
-    for (unsigned int i = 0; i < facePos.size(); i++) {
+    for (std::size_t i = 0; i < facePos.size(); i++) {
       if (facePos[i].element / maxChunkSize == static_cast<unsigned int>(m_rank))
         boundaries[(facePos[i].element % maxChunkSize) * 4 + facePos[i].side] = faceType[i];
       else {

--- a/src/meshreader/ParallelGambitReader.h
+++ b/src/meshreader/ParallelGambitReader.h
@@ -41,11 +41,11 @@ class ParallelGambitReader : public ParallelMeshReader<GambitReader> {
 
     if (m_rank == 0) {
       std::size_t maxChunkSize = chunkSize;
-      std::vector<ElementGroup> map (maxChunkSize);
+      std::vector<ElementGroup> map(maxChunkSize);
 
-      std::vector<std::vector<int>> aggregator (m_nProcs - 1);
-      std::vector<std::size_t> sizes (m_nProcs - 1);
-      std::vector<MPI_Request> requests ((m_nProcs - 1) * 2, MPI_REQUEST_NULL);
+      std::vector<std::vector<int>> aggregator(m_nProcs - 1);
+      std::vector<std::size_t> sizes(m_nProcs - 1);
+      std::vector<MPI_Request> requests((m_nProcs - 1) * 2, MPI_REQUEST_NULL);
 
       for (int i = 0; i < m_nProcs; i++) {
         logInfo() << "Reading group information part" << (i + 1) << "of" << m_nProcs;
@@ -83,7 +83,8 @@ class ParallelGambitReader : public ParallelMeshReader<GambitReader> {
           }
 
           sizes[j] = aggregator[j].size() / 2; // element id + group number
-          MPI_Isend(&sizes[j], 1, tndm::mpi_type_t<std::size_t>(), j + 1, 0, m_comm, &requests[j * 2]);
+          MPI_Isend(&sizes[j], 1, tndm::mpi_type_t<std::size_t>(), j + 1, 0, m_comm,
+                    &requests[j * 2]);
           MPI_Isend(&aggregator[j][0], aggregator[j].size(), MPI_INT, j + 1, 0, m_comm,
                     &requests[j * 2 + 1]);
         }
@@ -129,11 +130,11 @@ class ParallelGambitReader : public ParallelMeshReader<GambitReader> {
 
     if (m_rank == 0) {
       std::size_t maxChunkSize = chunkSize;
-      std::vector<GambitBoundaryFace> faces (maxChunkSize);
+      std::vector<GambitBoundaryFace> faces(maxChunkSize);
 
-      std::vector<std::vector<int>> aggregator (m_nProcs - 1);
-      std::vector<std::size_t> sizes (m_nProcs - 1);
-      std::vector<MPI_Request> requests ((m_nProcs - 1) * 2, MPI_REQUEST_NULL);
+      std::vector<std::vector<int>> aggregator(m_nProcs - 1);
+      std::vector<std::size_t> sizes(m_nProcs - 1);
+      std::vector<MPI_Request> requests((m_nProcs - 1) * 2, MPI_REQUEST_NULL);
 
       std::size_t nChunks = (nBoundaries() + chunkSize - 1) / chunkSize;
       for (std::size_t i = 0; i < nChunks; i++) {
@@ -171,7 +172,8 @@ class ParallelGambitReader : public ParallelMeshReader<GambitReader> {
           }
 
           sizes[j] = aggregator[j].size() / 2; // element id + face type
-          MPI_Isend(&sizes[j], 1, tndm::mpi_type_t<std::size_t>(), j + 1, 0, m_comm, &requests[j * 2]);
+          MPI_Isend(&sizes[j], 1, tndm::mpi_type_t<std::size_t>(), j + 1, 0, m_comm,
+                    &requests[j * 2]);
           MPI_Isend(&aggregator[j][0], aggregator[j].size(), MPI_INT, j + 1, 0, m_comm,
                     &requests[j * 2 + 1]);
         }
@@ -191,7 +193,7 @@ class ParallelGambitReader : public ParallelMeshReader<GambitReader> {
       }
 
       // Allocate enough memory
-      std::vector<int> buf (chunkSize * 2);
+      std::vector<int> buf(chunkSize * 2);
 
       while (true) {
         std::size_t size;

--- a/src/meshreader/ParallelMeshReader.h
+++ b/src/meshreader/ParallelMeshReader.h
@@ -166,7 +166,8 @@ template <class R> class ParallelMeshReader {
         logInfo() << "Reading elements part" << (m_nProcs - 1) << "of" << m_nProcs;
         m_serialReader.readElements((m_nProcs - 1) * chunkSize, lastChunkSize, elements);
         MPI_Wait(&request, MPI_STATUS_IGNORE);
-        MPI_Isend(elements, lastChunkSize * 4, tndm::mpi_type_t<std::size_t>(), m_nProcs - 1, 0, m_comm, &request);
+        MPI_Isend(elements, lastChunkSize * 4, tndm::mpi_type_t<std::size_t>(), m_nProcs - 1, 0,
+                  m_comm, &request);
         swap(elements, elements2);
       }
 
@@ -178,7 +179,8 @@ template <class R> class ParallelMeshReader {
       if (m_rank == m_nProcs - 1)
         chunkSize = m_nElements - (m_nProcs - 1) * chunkSize;
 
-      MPI_Recv(elements, chunkSize * 4, tndm::mpi_type_t<std::size_t>(), 0, 0, m_comm, MPI_STATUS_IGNORE);
+      MPI_Recv(elements, chunkSize * 4, tndm::mpi_type_t<std::size_t>(), 0, 0, m_comm,
+               MPI_STATUS_IGNORE);
     }
   }
 

--- a/src/meshreader/ParallelMeshReader.h
+++ b/src/meshreader/ParallelMeshReader.h
@@ -15,14 +15,17 @@
 
 #include <mpi.h>
 
+#include <array>
 #include <vector>
+
+#include "third_party/MPITraits.h"
 
 template <class R> class ParallelMeshReader {
   private:
   // Some variables that are required by all processes
-  unsigned int m_nVertices;
-  unsigned int m_nElements;
-  unsigned int m_nBoundaries;
+  std::size_t m_nVertices;
+  std::size_t m_nElements;
+  std::size_t m_nBoundaries;
 
   protected:
   const MPI_Comm m_comm;
@@ -50,7 +53,7 @@ template <class R> class ParallelMeshReader {
   virtual ~ParallelMeshReader() {}
 
   void open(const char* meshFile) {
-    unsigned int vars[3];
+    std::array<std::size_t, 3> vars;
 
     if (m_rank == 0) {
       m_serialReader.open(meshFile);
@@ -60,21 +63,21 @@ template <class R> class ParallelMeshReader {
       vars[2] = m_serialReader.nBoundaries();
     }
 
-    MPI_Bcast(vars, 3, MPI_UNSIGNED, 0, m_comm);
+    MPI_Bcast(vars.data(), 3, tndm::mpi_type_t<std::size_t>(), 0, m_comm);
 
     m_nVertices = vars[0];
     m_nElements = vars[1];
     m_nBoundaries = vars[2];
   }
 
-  unsigned int nVertices() const { return m_nVertices; }
+  std::size_t nVertices() const { return m_nVertices; }
 
-  unsigned int nElements() const { return m_nElements; }
+  std::size_t nElements() const { return m_nElements; }
 
   /**
    * @return Number of boundary faces
    */
-  unsigned int nBoundaries() const { return m_nBoundaries; }
+  std::size_t nBoundaries() const { return m_nBoundaries; }
 
   /**
    * Reads all vertices
@@ -86,11 +89,12 @@ template <class R> class ParallelMeshReader {
    * @todo Only 3 dimensional meshes are supported
    */
   void readVertices(double* vertices) {
-    unsigned int chunkSize = (m_nVertices + m_nProcs - 1) / m_nProcs;
+    std::size_t chunkSize = (m_nVertices + m_nProcs - 1) / m_nProcs;
 
     if (m_rank == 0) {
       // Allocate second buffer so we can read and send in parallel
-      double* vertices2 = new double[chunkSize * 3];
+      std::vector<double> tempVertices(chunkSize * 3);
+      double* vertices2 = tempVertices.data();
       if (m_nProcs % 2 == 0)
         // swap once so we have the correct buffer at the end
         swap(vertices, vertices2);
@@ -106,7 +110,7 @@ template <class R> class ParallelMeshReader {
 
       if (m_nProcs > 1) {
         // Read last one
-        unsigned int lastChunkSize = m_nVertices - (m_nProcs - 1) * chunkSize;
+        const std::size_t lastChunkSize = m_nVertices - (m_nProcs - 1) * chunkSize;
         logInfo() << "Reading vertices part" << (m_nProcs - 1) << "of" << m_nProcs;
         m_serialReader.readVertices((m_nProcs - 1) * chunkSize, lastChunkSize, vertices);
         MPI_Wait(&request, MPI_STATUS_IGNORE);
@@ -118,8 +122,6 @@ template <class R> class ParallelMeshReader {
       logInfo() << "Reading vertices part" << m_nProcs << "of" << m_nProcs;
       m_serialReader.readVertices(0, chunkSize, vertices);
       MPI_Wait(&request, MPI_STATUS_IGNORE);
-
-      delete[] vertices2;
     } else {
       if (m_rank == m_nProcs - 1)
         chunkSize = m_nVertices - (m_nProcs - 1) * chunkSize;
@@ -137,12 +139,13 @@ template <class R> class ParallelMeshReader {
    *
    * @todo Only tetrahedral meshes are supported
    */
-  virtual void readElements(int* elements) {
-    unsigned int chunkSize = (m_nElements + m_nProcs - 1) / m_nProcs;
+  virtual void readElements(std::size_t* elements) {
+    std::size_t chunkSize = (m_nElements + m_nProcs - 1) / m_nProcs;
 
     if (m_rank == 0) {
       // Allocate second buffer so we can read and send in parallel
-      int* elements2 = new int[chunkSize * 4];
+      std::vector<std::size_t> tempElements(chunkSize * 4);
+      std::size_t* elements2 = tempElements.data();
       if (m_nProcs % 2 == 0)
         // swap once so we have the correct buffer at the end
         swap(elements, elements2);
@@ -153,17 +156,17 @@ template <class R> class ParallelMeshReader {
         logInfo() << "Reading elements part" << i << "of" << m_nProcs;
         m_serialReader.readElements(i * chunkSize, chunkSize, elements);
         MPI_Wait(&request, MPI_STATUS_IGNORE);
-        MPI_Isend(elements, chunkSize * 4, MPI_INT, i, 0, m_comm, &request);
+        MPI_Isend(elements, chunkSize * 4, tndm::mpi_type_t<std::size_t>(), i, 0, m_comm, &request);
         swap(elements, elements2);
       }
 
       if (m_nProcs > 1) {
         // Read last one
-        unsigned int lastChunkSize = m_nElements - (m_nProcs - 1) * chunkSize;
+        const std::size_t lastChunkSize = m_nElements - (m_nProcs - 1) * chunkSize;
         logInfo() << "Reading elements part" << (m_nProcs - 1) << "of" << m_nProcs;
         m_serialReader.readElements((m_nProcs - 1) * chunkSize, lastChunkSize, elements);
         MPI_Wait(&request, MPI_STATUS_IGNORE);
-        MPI_Isend(elements, lastChunkSize * 4, MPI_INT, m_nProcs - 1, 0, m_comm, &request);
+        MPI_Isend(elements, lastChunkSize * 4, tndm::mpi_type_t<std::size_t>(), m_nProcs - 1, 0, m_comm, &request);
         swap(elements, elements2);
       }
 
@@ -171,13 +174,11 @@ template <class R> class ParallelMeshReader {
       logInfo() << "Reading elements part" << m_nProcs << "of" << m_nProcs;
       m_serialReader.readElements(0, chunkSize, elements);
       MPI_Wait(&request, MPI_STATUS_IGNORE);
-
-      delete[] elements2;
     } else {
       if (m_rank == m_nProcs - 1)
         chunkSize = m_nElements - (m_nProcs - 1) * chunkSize;
 
-      MPI_Recv(elements, chunkSize * 4, MPI_INT, 0, 0, m_comm, MPI_STATUS_IGNORE);
+      MPI_Recv(elements, chunkSize * 4, tndm::mpi_type_t<std::size_t>(), 0, 0, m_comm, MPI_STATUS_IGNORE);
     }
   }
 

--- a/src/pumgen.cpp
+++ b/src/pumgen.cpp
@@ -443,7 +443,7 @@ int main(int argc, char* argv[]) {
   checkH5Err(H5Pclose(h5falist));
 
   // Write cells
-  std::size_t connectSize = 8;
+  std::size_t connectBytesPerData = 8;
   logInfo(rank) << "Writing cells";
   writeH5Data<unsigned long, 4>(
       [&](auto& element, auto&& data) {
@@ -489,7 +489,7 @@ int main(int argc, char* argv[]) {
   // Group information
   apf::MeshTag* groupTag = mesh->findTag("group");
 
-  std::size_t groupSize = 4;
+  std::size_t groupBytesPerData = 4;
   if (groupTag) {
     logInfo(rank) << "Writing group information";
     writeH5Data<int, NoSecondDim>(
@@ -561,7 +561,7 @@ int main(int argc, char* argv[]) {
          << std::endl
          // This should be UInt but for some reason this does not work with
          // binary data
-         << "    <DataItem NumberType=\"Int\" Precision=\"" << connectSize
+         << "    <DataItem NumberType=\"Int\" Precision=\"" << connectBytesPerData
          << "\" Format=\"HDF\" "
             "Dimensions=\""
          << globalSize[0] << " 4\">" << basename << ":/connect</DataItem>" << std::endl
@@ -573,7 +573,7 @@ int main(int argc, char* argv[]) {
          << ":/geometry</DataItem>" << std::endl
          << "   </Geometry>" << std::endl
          << "   <Attribute Name=\"group\" Center=\"Cell\">" << std::endl
-         << "    <DataItem  NumberType=\"Int\" Precision=\"" << groupSize
+         << "    <DataItem  NumberType=\"Int\" Precision=\"" << groupBytesPerData
          << "\" Format=\"HDF\" "
             "Dimensions=\""
          << globalSize[0] << "\">" << basename << ":/group</DataItem>" << std::endl

--- a/src/pumgen.cpp
+++ b/src/pumgen.cpp
@@ -579,9 +579,9 @@ int main(int argc, char* argv[]) {
          << globalSize[0] << "\">" << basename << ":/group</DataItem>" << std::endl
          << "   </Attribute>" << std::endl
          << "   <Attribute Name=\"boundary\" Center=\"Cell\">" << std::endl
-         << "    <DataItem NumberType=\"Int\" Precision=\"4\" Format=\"HDF\" "
-            "Dimensions=\""
-         << globalSize[0] << "\">" << basename << ":/boundary</DataItem>" << std::endl
+         << "    <DataItem NumberType=\"Int\" Precision=\"" << (boundaryType == 0 ? "4" : "8")
+         << "\" Format=\"HDF\" Dimensions=\"" << globalSize[0] << "\">" << basename
+         << ":/boundary</DataItem>" << std::endl
          << "   </Attribute>" << std::endl
          << "  </Grid>" << std::endl
          << " </Domain>" << std::endl


### PR DESCRIPTION
As stated, this PR adds large mesh support—or rather, it corrects the few spots where that wasn't the case yet (that is, the Simmodeller should have been able to do that already). For the large meshes to work, this PR requires a SCOREC/PUMI version which is newer than v2.2.7; seemingly only directly using `master` works right now for that (i.e. one which would not have worked before #58 ). Older PUMI versions are still supported, and PUMgen should work as usual (cf. #58 ), but they probably won't support larger meshes, due to the element data type in APF.

Some additional features:

* We add some compression options for the output—if that's wanted or needed. (note that most compression options can also be applied, changed or removed by using `h5repack` and the resulting size is roughly the same as storing a PUML mesh in a ZIP file)
* Furthermore, we add chunked output writing for large meshes.
* Also, we integrate 64-bit boundaries natively into PUMgen (groups still stay 32-bit at the moment).

Some of the older mesh formats may break during this update and may be removed some time soon-ish.