### PR TITLE
Support GMSH files with Windows-style line endings

### DIFF
--- a/src/third_party/GMSHLexer.cpp
+++ b/src/third_party/GMSHLexer.cpp
@@ -23,8 +23,11 @@ GMSHToken GMSHLexer::getToken() {
         return GMSHToken::eof;
     }
 
-    while (isspace(lastChar)) {
+    while (isspace(lastChar) && in->good()) {
         advance();
+    }
+    if (!in->good()) {
+        return GMSHToken::eof;
     }
 
     if (lastChar == '$') {


### PR DESCRIPTION
Fixes #54 , i.e. support for Windows-style line endings (the error messages will still be messed up, though, as we increment the `line` position in the reader by 2 at each Windows-style line ending). The problem would have most likely also occurred when trying to convert msh4 files.