### PR TITLE
Set boundary format string storage size to variable

### DIFF
--- a/src/aux/MPIConvenience.cpp
+++ b/src/aux/MPIConvenience.cpp
@@ -43,8 +43,6 @@ void sparseAlltoallv(const void* sendbuf, const std::size_t* sendsize, const std
                      const std::size_t* recvdisp, MPI_Datatype recvtype, MPI_Comm comm) {
   int commsize;
   int commrank;
-  int sendtypesizePre;
-  int recvtypesizePre;
   MPI_Comm_size(comm, &commsize);
   MPI_Comm_rank(comm, &commrank);
 

--- a/src/pumgen.cpp
+++ b/src/pumgen.cpp
@@ -448,10 +448,11 @@ int main(int argc, char* argv[]) {
 
   hid_t attrSpace = checkH5Err(H5Screate(H5S_SCALAR));
   hid_t attrType = checkH5Err(H5Tcopy(H5T_C_S1));
-  checkH5Err(H5Tset_size(attrType, boundaryFormatAttr.size() + 1));
+  checkH5Err(H5Tset_size(attrType, H5T_VARIABLE));
   hid_t attrBoundary = checkH5Err(
       H5Acreate(h5file, "boundary-format", attrType, attrSpace, H5P_DEFAULT, H5P_DEFAULT));
-  checkH5Err(H5Awrite(attrBoundary, attrType, boundaryFormatAttr.data()));
+  void* stringData = boundaryFormatAttr.data();
+  checkH5Err(H5Awrite(attrBoundary, attrType, &stringData));
   checkH5Err(H5Aclose(attrBoundary));
   checkH5Err(H5Sclose(attrSpace));
   checkH5Err(H5Tclose(attrType));


### PR DESCRIPTION
(matching with the current SeisSol parsing—which is to be fixed as well)