### PR TITLE
Remove PUMI from the CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,52 +3,9 @@ name: CMake
 on: [push]
 
 jobs:
-  # look into the cache, if the latest PUMI build is cached, load the cache, otherwise build new cache.
-  # upload PUMI build into artifact to be picked up by the next job.
-  install-pumi:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout PUMI
-        id: checkout-pumi
-        run: |
-            cd ${{ runner.workspace }}
-            mkdir opt
-            git clone --recursive --branch v2.2.7 --depth 1 https://github.com/SCOREC/core.git
-            cd core
-            echo "pumi-id=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Cache PUMI
-        id: cache-pumi
-        uses: actions/cache@v3
-        with:
-          path: ${{ runner.workspace }}/opt
-          key: ${{ steps.checkout-pumi.outputs.pumi-id }}
-
-      - if: ${{ steps.cache-pumi.outputs.cache-hit != 'true' }}
-        name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -qq g++ openmpi-bin openmpi-common libopenmpi-dev hdf5-tools libhdf5-openmpi-103 libhdf5-openmpi-dev libnetcdf-dev
-
-      - if: ${{ steps.cache-pumi.outputs.cache-hit != 'true' }}
-        name: Install PUMI
-        run: |
-            cd ${{ runner.workspace }}/core
-            git submodule update --init
-            mkdir build && cd build
-            cmake .. -DCMAKE_C_COMPILER="`which mpicc`" -DCMAKE_CXX_COMPILER="`which mpiCC`" -DSCOREC_CXX_FLAGS="-O2 -g -Wall -DOMPI_SKIP_MPICXX" -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/opt
-            make -j $(nproc) && make install
-
-      - name: Upload PUMI
-        uses: actions/upload-artifact@v3
-        with:
-          name: pumi
-          path: ${{ runner.workspace }}/opt
-
   # Build pumgen in Release and Debug version
   build-pumgen:
     runs-on: ubuntu-latest
-    needs: install-pumi
 
     strategy:
       matrix:
@@ -61,19 +18,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -qq g++ openmpi-bin openmpi-common libopenmpi-dev hdf5-tools libhdf5-openmpi-103 libhdf5-openmpi-dev libnetcdf-dev
-
-      - name: Download PUMI
-        uses: actions/download-artifact@v3
-        with:
-          name: pumi
-          path: ${{ runner.workspace }}/opt
   
       - name: Configure PUMGen
         working-directory: ${{ github.workspace }}
         run: |
-          git submodule update --init
+          git submodule update --init --recursive
           mkdir build_${{ matrix.build_type}} && cd build_${{ matrix.build_type}}
-          CC=mpicc CXX=mpiCC cmake .. -DCMAKE_PREFIX_PATH=${{ runner.workspace }}/opt -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake .. -DCMAKE_PREFIX_PATH=${{ runner.workspace }}/opt -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
   
       - name: Build
         working-directory: ${{ github.workspace }}/build_${{ matrix.build_type }}


### PR DESCRIPTION
PUMI hasn't been used in the CI anymore (we don't have Simmodeler there) since #68 , so it can be safely removed.

Fixes #78 .