### PR TITLE
Update to checkout v5

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
         build_type: ["Release", "Debug"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |
@@ -33,7 +33,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: clang-format
         run: |


### PR DESCRIPTION
Cf. https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/