### PR TITLE
fix typo in gmsh4

### DIFF
--- a/src/pumgen.cpp
+++ b/src/pumgen.cpp
@@ -173,7 +173,7 @@ static void writeH5Data(const F& handler, hid_t h5file, const std::string& name,
 template <std::size_t Order>
 using SMF2 = SerialMeshFile<puml::ParallelGMSHReader<tndm::GMSH2Parser, Order>>;
 template <std::size_t Order>
-using SMF4 = SerialMeshFile<puml::ParallelGMSHReader<tndm::GMSH2Parser, Order>>;
+using SMF4 = SerialMeshFile<puml::ParallelGMSHReader<puml::GMSH4Parser, Order>>;
 
 int main(int argc, char* argv[]) {
   int rank = 0;


### PR DESCRIPTION
fix copy-paste error and make msh4 format work again.
